### PR TITLE
Fix schemastore-catalog CI: invoke lintel check as library

### DIFF
--- a/.github/workflows/schemastore-catalog.yml
+++ b/.github/workflows/schemastore-catalog.yml
@@ -16,13 +16,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "workspace"
-      - run: cargo build --release -p lintel-schemastore-catalog -p lintel
       - name: Configure git
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - name: Update catalog
-        run: ./target/release/lintel-schemastore-catalog update
+        run: cargo run --release -p lintel-schemastore-catalog -- update
         env:
           GITHUB_TOKEN: ${{ secrets.SCHEMASTORE_CATALOG_GITHUB_PAT }}
-          PATH: ./target/release:${{ env.PATH }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,8 @@ dependencies = [
  "anyhow",
  "bpaf",
  "futures",
+ "lintel-check",
+ "lintel-schema-cache",
  "reqwest 0.12.28",
  "schemastore",
  "serde",

--- a/crates/lintel-schemastore-catalog/Cargo.toml
+++ b/crates/lintel-schemastore-catalog/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 
 [dependencies]
 schemastore = { version = "0.0.2", path = "../schemastore" }
+lintel-check = { version = "0.0.2", path = "../lintel-check" }
+lintel-schema-cache = { version = "0.0.2", path = "../lintel-schema-cache" }
 bpaf = { version = "0.9", features = ["derive", "bright-color"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }


### PR DESCRIPTION
## Summary

- **Invoke lintel check as a library** instead of spawning a subprocess, eliminating the need to build and place the `lintel` binary on `PATH`
- **Fix CI failure** where `${{ env.PATH }}` resolved to empty in the GitHub Actions `env:` block, making `git` (and `lintel`) invisible to the subprocess
- **Simplify workflow** to use `cargo run --release` — removes separate build step and PATH manipulation

## Test plan

- [ ] Verify `cargo check -p lintel-schemastore-catalog` passes
- [ ] Trigger the schemastore-catalog workflow manually and confirm it completes successfully