### PR TITLE
Remove lintel check from schemastore catalog update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,8 +1279,6 @@ dependencies = [
  "anyhow",
  "bpaf",
  "futures",
- "lintel-check",
- "lintel-schema-cache",
  "reqwest 0.12.28",
  "schemastore",
  "serde",

--- a/crates/lintel-schemastore-catalog/Cargo.toml
+++ b/crates/lintel-schemastore-catalog/Cargo.toml
@@ -15,8 +15,6 @@ workspace = true
 
 [dependencies]
 schemastore = { version = "0.0.2", path = "../schemastore" }
-lintel-check = { version = "0.0.2", path = "../lintel-check" }
-lintel-schema-cache = { version = "0.0.2", path = "../lintel-schema-cache" }
 bpaf = { version = "0.9", features = ["derive", "bright-color"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }


### PR DESCRIPTION
## Summary
- Removes the `lintel check` validation step from the schemastore catalog update command, as it's not needed
- Drops `lintel-check` and `lintel-schema-cache` dependencies from the `lintel-schemastore-catalog` crate

## Test plan
- [x] `cargo check -p lintel-schemastore-catalog` passes