### PR TITLE
Improve caching, Nix build, and crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
+repository = "https://github.com/lintel-rs/lintel"
+license = "Apache-2.0"
+authors = ["Ian Macalinao <me@ianm.com>"]
+homepage = "https://github.com/lintel-rs/lintel"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/lintel-benchmark/Cargo.toml
+++ b/crates/lintel-benchmark/Cargo.toml
@@ -2,7 +2,13 @@
 name = "lintel-benchmark"
 version = "0.0.1"
 edition.workspace = true
-publish = false
+description = "Benchmarking harness for Lintel — runs validation against real-world repos and records timing results"
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+authors.workspace = true
+keywords = ["json-schema", "benchmark", "validation"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 anyhow = "1"

--- a/crates/lintel-benchmark/README.md
+++ b/crates/lintel-benchmark/README.md
@@ -1,0 +1,20 @@
+# lintel-benchmark
+
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/lintel-benchmark.svg
+[crates-url]: https://crates.io/crates/lintel-benchmark
+[docs-badge]: https://docs.rs/lintel-benchmark/badge.svg
+[docs-url]: https://docs.rs/lintel-benchmark
+[license-badge]: https://img.shields.io/crates/l/lintel-benchmark.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
+Benchmarking harness for [Lintel](https://github.com/lintel-rs/lintel). Runs validation against real-world repositories and records timing results for performance tracking.
+
+## Usage
+
+```shell
+cargo run -p lintel-benchmark
+```

--- a/crates/lintel-check/Cargo.toml
+++ b/crates/lintel-check/Cargo.toml
@@ -2,14 +2,13 @@
 name = "lintel-check"
 version = "0.0.2"
 edition.workspace = true
-authors = ["Ian Macalinao <me@ianm.com>"]
+authors.workspace = true
 description = "Core validation engine for Lintel — validates JSON, YAML, TOML, JSON5, and JSONC against JSON Schema"
-license = "Apache-2.0"
-repository = "https://github.com/lintel-rs/lintel"
-homepage = "https://github.com/lintel-rs/lintel"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["json-schema", "validation", "yaml", "toml", "linter"]
 categories = ["development-tools"]
-readme = "README.md"
 
 [dependencies]
 lintel-config = { version = "0.0.1", path = "../lintel-config" }

--- a/crates/lintel-check/README.md
+++ b/crates/lintel-check/README.md
@@ -1,5 +1,16 @@
 # lintel-check
 
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/lintel-check.svg
+[crates-url]: https://crates.io/crates/lintel-check
+[docs-badge]: https://docs.rs/lintel-check/badge.svg
+[docs-url]: https://docs.rs/lintel-check
+[license-badge]: https://img.shields.io/crates/l/lintel-check.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
 Core validation engine for [Lintel](https://github.com/lintel-rs/lintel). Validates JSON, YAML, TOML, JSON5, and JSONC files against JSON Schema.
 
 ## Features

--- a/crates/lintel-config/Cargo.toml
+++ b/crates/lintel-config/Cargo.toml
@@ -2,11 +2,11 @@
 name = "lintel-config"
 version = "0.0.1"
 edition.workspace = true
-authors = ["Ian Macalinao <me@ianm.com>"]
+authors.workspace = true
 description = "Configuration types and loader for Lintel (lintel.toml)"
-license = "Apache-2.0"
-repository = "https://github.com/lintel-rs/lintel"
-homepage = "https://github.com/lintel-rs/lintel"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["json-schema", "validation", "config"]
 categories = ["development-tools"]
 

--- a/crates/lintel-config/README.md
+++ b/crates/lintel-config/README.md
@@ -1,5 +1,16 @@
 # lintel-config
 
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/lintel-config.svg
+[crates-url]: https://crates.io/crates/lintel-config
+[docs-badge]: https://docs.rs/lintel-config/badge.svg
+[docs-url]: https://docs.rs/lintel-config
+[license-badge]: https://img.shields.io/crates/l/lintel-config.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
 Configuration types and loader for [Lintel](https://github.com/lintel-rs/lintel). Defines the `lintel.toml` schema, parses config files, and provides utilities for schema URI rewriting and path resolution.
 
 ## Features

--- a/crates/lintel-schema-cache/Cargo.toml
+++ b/crates/lintel-schema-cache/Cargo.toml
@@ -2,14 +2,13 @@
 name = "lintel-schema-cache"
 version = "0.0.2"
 edition.workspace = true
-authors = ["Ian Macalinao <me@ianm.com>"]
+authors.workspace = true
 description = "Disk-backed cache for JSON Schema files with pluggable HTTP and jsonschema integration"
-license = "Apache-2.0"
-repository = "https://github.com/lintel-rs/lintel"
-homepage = "https://github.com/lintel-rs/lintel"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["json-schema", "cache", "schema"]
 categories = ["caching", "development-tools"]
-readme = "README.md"
 
 [dependencies]
 jsonschema = { version = "0.42", features = ["resolve-async"] }

--- a/crates/lintel-schema-cache/README.md
+++ b/crates/lintel-schema-cache/README.md
@@ -1,5 +1,16 @@
 # lintel-schema-cache
 
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/lintel-schema-cache.svg
+[crates-url]: https://crates.io/crates/lintel-schema-cache
+[docs-badge]: https://docs.rs/lintel-schema-cache/badge.svg
+[docs-url]: https://docs.rs/lintel-schema-cache
+[license-badge]: https://img.shields.io/crates/l/lintel-schema-cache.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
 Disk-backed cache for JSON Schema files. Fetches schemas over HTTP and stores them locally for fast subsequent lookups.
 
 ## Features

--- a/crates/lintel-schemastore-catalog/Cargo.toml
+++ b/crates/lintel-schemastore-catalog/Cargo.toml
@@ -2,11 +2,11 @@
 name = "lintel-schemastore-catalog"
 version = "0.0.2"
 edition.workspace = true
-authors = ["Ian Macalinao <me@ianm.com>"]
+authors.workspace = true
 description = "Mirror the SchemaStore catalog into a self-hosted git repo"
-license = "Apache-2.0"
-repository = "https://github.com/lintel-rs/lintel"
-homepage = "https://github.com/lintel-rs/lintel"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["json-schema", "schemastore", "catalog"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/crates/lintel-schemastore-catalog/README.md
+++ b/crates/lintel-schemastore-catalog/README.md
@@ -1,5 +1,16 @@
 # lintel-schemastore-catalog
 
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/lintel-schemastore-catalog.svg
+[crates-url]: https://crates.io/crates/lintel-schemastore-catalog
+[docs-badge]: https://docs.rs/lintel-schemastore-catalog/badge.svg
+[docs-url]: https://docs.rs/lintel-schemastore-catalog
+[license-badge]: https://img.shields.io/crates/l/lintel-schemastore-catalog.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
 CLI tool that mirrors the entire [SchemaStore](https://www.schemastore.org/) catalog (catalog index + all schema files) into a git repo, keeping it up to date via CI.
 
 This gives [lintel](https://github.com/lintel-rs/lintel) a self-hosted, version-controlled schema source at [`lintel-rs/schemastore-catalog`](https://github.com/lintel-rs/schemastore-catalog).

--- a/crates/lintel-validation-cache/Cargo.toml
+++ b/crates/lintel-validation-cache/Cargo.toml
@@ -2,11 +2,11 @@
 name = "lintel-validation-cache"
 version = "0.0.1"
 edition.workspace = true
-authors = ["Ian Macalinao <me@ianm.com>"]
+authors.workspace = true
 description = "Disk-backed cache for JSON Schema validation results"
-license = "Apache-2.0"
-repository = "https://github.com/lintel-rs/lintel"
-homepage = "https://github.com/lintel-rs/lintel"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["json-schema", "cache", "validation"]
 categories = ["caching", "development-tools"]
 

--- a/crates/lintel-validation-cache/README.md
+++ b/crates/lintel-validation-cache/README.md
@@ -1,0 +1,36 @@
+# lintel-validation-cache
+
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/lintel-validation-cache.svg
+[crates-url]: https://crates.io/crates/lintel-validation-cache
+[docs-badge]: https://docs.rs/lintel-validation-cache/badge.svg
+[docs-url]: https://docs.rs/lintel-validation-cache
+[license-badge]: https://img.shields.io/crates/l/lintel-validation-cache.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
+Disk-backed cache for JSON Schema validation results. Caches the outcome of validating a file against a schema so that unchanged files can skip re-validation on subsequent runs.
+
+Part of the [Lintel](https://github.com/lintel-rs/lintel) project.
+
+## How it works
+
+Each cache entry is keyed by a SHA-256 digest of the file contents and schema URI. When a file hasn't changed since the last run, the cached validation result is returned instantly — no parsing or schema evaluation needed.
+
+## Usage
+
+```rust
+use lintel_validation_cache::ValidationCache;
+
+let cache = ValidationCache::new(Some(cache_dir)).await?;
+
+// Check if a result is cached
+if let Some(result) = cache.get(&file_hash, &schema_uri).await? {
+    // Use cached result
+}
+
+// Store a new result
+cache.set(&file_hash, &schema_uri, &result).await?;
+```

--- a/crates/lintel/Cargo.toml
+++ b/crates/lintel/Cargo.toml
@@ -2,14 +2,13 @@
 name = "lintel"
 version = "0.0.2"
 edition.workspace = true
-authors = ["Ian Macalinao <me@ianm.com>"]
+authors.workspace = true
 description = "Validate JSON and YAML files against JSON Schema"
-license = "Apache-2.0"
-repository = "https://github.com/lintel-rs/lintel"
-homepage = "https://github.com/lintel-rs/lintel"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["json-schema", "validation", "yaml", "linter", "cli"]
 categories = ["command-line-utilities", "development-tools"]
-readme = "../../README.md"
 
 [dependencies]
 lintel-check = { version = "0.0.2", path = "../lintel-check" }

--- a/crates/lintel/README.md
+++ b/crates/lintel/README.md
@@ -1,0 +1,64 @@
+# lintel
+
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/lintel.svg
+[crates-url]: https://crates.io/crates/lintel
+[docs-badge]: https://docs.rs/lintel/badge.svg
+[docs-url]: https://docs.rs/lintel
+[license-badge]: https://img.shields.io/crates/l/lintel.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
+Fast, multi-format JSON Schema linter CLI. Validates JSON, YAML, TOML, JSON5, and JSONC files against [JSON Schema](https://json-schema.org/) in a single command.
+
+Part of the [Lintel](https://github.com/lintel-rs/lintel) project.
+
+## Installation
+
+```shell
+cargo install lintel
+```
+
+Or with npm:
+
+```shell
+npx lintel check
+```
+
+Or with Nix:
+
+```shell
+nix run github:lintel-rs/lintel
+```
+
+## Usage
+
+```shell
+# validate with rich terminal output
+lintel check
+
+# validate with CI-friendly one-error-per-line output
+lintel ci
+
+# generate a lintel.toml with auto-detected schemas
+lintel init
+
+# convert between formats
+lintel convert config.yaml --to toml
+```
+
+## Schema Discovery
+
+Lintel auto-discovers schemas in priority order:
+
+1. **YAML modeline** — `# yaml-language-server: $schema=...`
+2. **Inline `$schema` property** — in the document itself
+3. **`lintel.toml` mappings** — custom `[schemas]` table entries
+4. **Lintel catalog** — schemas for tools not in SchemaStore
+5. **SchemaStore catalog** — matching by filename
+
+## License
+
+Apache-2.0

--- a/crates/schemastore/Cargo.toml
+++ b/crates/schemastore/Cargo.toml
@@ -2,14 +2,13 @@
 name = "schemastore"
 version = "0.0.2"
 edition.workspace = true
-authors = ["Ian Macalinao <me@ianm.com>"]
+authors.workspace = true
 description = "Fetch and match files against the SchemaStore catalog"
-license = "Apache-2.0"
-repository = "https://github.com/lintel-rs/lintel"
-homepage = "https://github.com/lintel-rs/lintel"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 keywords = ["json-schema", "schemastore", "validation"]
 categories = ["development-tools"]
-readme = "README.md"
 
 [lints]
 workspace = true

--- a/crates/schemastore/README.md
+++ b/crates/schemastore/README.md
@@ -1,5 +1,16 @@
 # schemastore
 
+[![Crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![License][license-badge]][license-url]
+
+[crates-badge]: https://img.shields.io/crates/v/schemastore.svg
+[crates-url]: https://crates.io/crates/schemastore
+[docs-badge]: https://docs.rs/schemastore/badge.svg
+[docs-url]: https://docs.rs/schemastore
+[license-badge]: https://img.shields.io/crates/l/schemastore.svg
+[license-url]: https://github.com/lintel-rs/lintel/blob/master/LICENSE
+
 Parse and match files against the [SchemaStore](https://www.schemastore.org/) catalog.
 
 SchemaStore is a community-maintained collection of JSON Schema definitions for common configuration files. This crate deserializes the catalog and matches file paths to their corresponding schemas using the `fileMatch` glob patterns.


### PR DESCRIPTION
## Summary

- Fix cache dir creation with `temp_dir` fallback and migrate cache I/O to async `tokio::fs`
- Fix Nix build by using `installShellFiles` instead of `installShellCompletion`
- Add per-crate READMEs with crates.io, docs.rs, and license badges
- Inherit `repository`, `license`, `authors`, and `homepage` from `[workspace.package]` across all crates
- Make `lintel-benchmark` publishable

## Test plan

- [ ] Verify `cargo check --workspace` passes
- [ ] Verify schema cache fallback works when default cache dir is unavailable
- [ ] Verify Nix build completes successfully
- [ ] Confirm all crate READMEs render correctly on crates.io