### PR TITLE
fix: trigger release workflows via workflow_dispatch

### DIFF
--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -3,6 +3,7 @@ name: Release GitHub Action
 on:
   push:
     tags: ["lintel-github-action-v*"]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,12 +23,29 @@ jobs:
         with:
           shared-key: "workspace"
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Trigger release workflow
+        if: steps.release-plz.outputs.releases != '[]'
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(echo "$RELEASES" | jq -r '.[] | select(.tag | startswith("lintel-v")) | .tag')
+          if [ -n "$TAG" ]; then
+            gh workflow run release.yml --ref "$TAG"
+          fi
+
+          ACTION_TAG=$(echo "$RELEASES" | jq -r '.[] | select(.tag | startswith("lintel-github-action-v")) | .tag')
+          if [ -n "$ACTION_TAG" ]; then
+            gh workflow run release-github-action.yml --ref "$ACTION_TAG"
+          fi
 
   release-plz-pr:
     name: Release-plz PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ["lintel-v*"]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Tags created by `GITHUB_TOKEN` don't trigger other workflows, so the Release and Release GitHub Action workflows were never firing
- Added `workflow_dispatch` trigger to both `release.yml` and `release-github-action.yml`
- Added a step in `release-plz.yml` to explicitly dispatch these workflows after tags are created, using `--ref <tag>` to ensure they run on the correct tag

## Test plan

- [ ] Merge and wait for next release-plz run to verify the release workflows are triggered