### PR TITLE
Build multi-arch Docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  docker:
-    name: Publish Docker Image
-    runs-on: ubuntu-latest
+  docker-build:
+    name: Docker (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
@@ -158,12 +165,31 @@ jobs:
       - name: Tag and push
         run: |
           VERSION=${GITHUB_REF_NAME#lintel-v}
+          ARCH_TAG=${VERSION}-${{ matrix.arch }}
+
+          docker tag ghcr.io/lintel-rs/lintel:latest ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${ARCH_TAG}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${ARCH_TAG}
+
+  docker-manifest:
+    name: Docker Manifest
+    needs: docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifests
+        run: |
+          VERSION=${GITHUB_REF_NAME#lintel-v}
           MAJOR_MINOR=${VERSION%.*}
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-          docker tag ghcr.io/lintel-rs/lintel:latest ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
-          docker tag ghcr.io/lintel-rs/lintel:latest ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${MAJOR_MINOR}
-          docker tag ghcr.io/lintel-rs/lintel:latest ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${MAJOR_MINOR}
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          for TAG in "${VERSION}" "${MAJOR_MINOR}" "latest"; do
+            docker manifest create ${IMAGE}:${TAG} \
+              ${IMAGE}:${VERSION}-amd64 \
+              ${IMAGE}:${VERSION}-arm64
+            docker manifest push ${IMAGE}:${TAG}
+          done


### PR DESCRIPTION
## Summary

- Replace single-arch `docker` job with a matrix `docker-build` job using native runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64)
- Add `docker-manifest` job that creates multi-arch manifest lists for `<version>`, `<major.minor>`, and `latest` tags
- Fixes `exec format error` when pulling the image on Apple Silicon Macs

## Test plan

- [ ] Trigger a release and confirm `docker manifest inspect ghcr.io/lintel-rs/lintel:latest` shows both `amd64` and `arm64` platforms
- [ ] Test `docker run --rm ghcr.io/lintel-rs/lintel:latest --version` on an Apple Silicon Mac without platform warning