### PR TITLE
refactor: extract lintel-identify crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,16 +1244,13 @@ version = "0.0.3"
 dependencies = [
  "anyhow",
  "bpaf",
- "glob-match",
- "humantime",
  "insta",
- "jsonschema-explain",
  "lintel-annotate",
  "lintel-check",
  "lintel-cli-common",
+ "lintel-identify",
  "lintel-reporters",
  "miette",
- "schemastore",
  "serde_json",
  "serde_yaml",
  "tokio",
@@ -1348,6 +1345,22 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "lintel-identify"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "bpaf",
+ "glob-match",
+ "humantime",
+ "jsonschema-explain",
+ "lintel-check",
+ "lintel-cli-common",
+ "schemastore",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/lintel-cli-common/src/lib.rs
+++ b/crates/lintel-cli-common/src/lib.rs
@@ -81,3 +81,90 @@ impl core::fmt::Display for LogLevel {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use bpaf::Parser;
+
+    fn opts() -> bpaf::OptionParser<CLIGlobalOptions> {
+        cli_global_options().to_options()
+    }
+
+    #[test]
+    fn defaults() {
+        let parsed = opts().run_inner(&[]).unwrap();
+        assert!(!parsed.verbose);
+        assert_eq!(parsed.log_level, LogLevel::None);
+        assert!(parsed.colors.is_none());
+    }
+
+    #[test]
+    fn verbose_short() {
+        let parsed = opts().run_inner(&["-v"]).unwrap();
+        assert!(parsed.verbose);
+    }
+
+    #[test]
+    fn verbose_long() {
+        let parsed = opts().run_inner(&["--verbose"]).unwrap();
+        assert!(parsed.verbose);
+    }
+
+    #[test]
+    fn log_level_debug() {
+        let parsed = opts().run_inner(&["--log-level", "debug"]).unwrap();
+        assert_eq!(parsed.log_level, LogLevel::Debug);
+    }
+
+    #[test]
+    fn log_level_info() {
+        let parsed = opts().run_inner(&["--log-level", "info"]).unwrap();
+        assert_eq!(parsed.log_level, LogLevel::Info);
+    }
+
+    #[test]
+    fn log_level_warn() {
+        let parsed = opts().run_inner(&["--log-level", "warn"]).unwrap();
+        assert_eq!(parsed.log_level, LogLevel::Warn);
+    }
+
+    #[test]
+    fn log_level_error() {
+        let parsed = opts().run_inner(&["--log-level", "error"]).unwrap();
+        assert_eq!(parsed.log_level, LogLevel::Error);
+    }
+
+    #[test]
+    fn log_level_invalid() {
+        assert!(opts().run_inner(&["--log-level", "trace"]).is_err());
+    }
+
+    #[test]
+    fn colors_off() {
+        let parsed = opts().run_inner(&["--colors", "off"]).unwrap();
+        assert_eq!(parsed.colors, Some(ColorsArg::Off));
+    }
+
+    #[test]
+    fn colors_force() {
+        let parsed = opts().run_inner(&["--colors", "force"]).unwrap();
+        assert_eq!(parsed.colors, Some(ColorsArg::Force));
+    }
+
+    #[test]
+    fn colors_invalid() {
+        assert!(opts().run_inner(&["--colors", "auto"]).is_err());
+    }
+
+    #[test]
+    fn combined_flags() {
+        let parsed = opts()
+            .run_inner(&["-v", "--log-level", "debug", "--colors", "force"])
+            .unwrap();
+        assert!(parsed.verbose);
+        assert_eq!(parsed.log_level, LogLevel::Debug);
+        assert_eq!(parsed.colors, Some(ColorsArg::Force));
+    }
+}

--- a/crates/lintel-identify/Cargo.toml
+++ b/crates/lintel-identify/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "lintel-identify"
+version = "0.0.1"
+edition.workspace = true
+authors.workspace = true
+description = "Schema identification for JSON and YAML files using JSON Schema"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["json-schema", "validation", "identification", "linter"]
+categories = ["development-tools"]
+
+[dependencies]
+lintel-check = { version = "0.0.4", path = "../lintel-check" }
+lintel-cli-common = { version = "0.0.1", path = "../lintel-cli-common" }
+schemastore = { version = "0.0.4", path = "../schemastore" }
+jsonschema-explain = { version = "0.1.0", path = "../jsonschema-explain" }
+bpaf = { version = "0.9", features = ["derive"] }
+humantime = "2"
+glob-match = "0.2"
+anyhow = "1"
+serde_json = "1"
+tracing = "0.1"
+
+[lints]
+workspace = true

--- a/crates/lintel-identify/src/lib.rs
+++ b/crates/lintel-identify/src/lib.rs
@@ -2,6 +2,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use bpaf::Bpaf;
 use lintel_cli_common::CLIGlobalOptions;
 
 use lintel_check::config;
@@ -10,7 +11,53 @@ use lintel_check::retriever::{HttpClient, SchemaCache, ensure_cache_dir};
 use lintel_check::validate;
 use schemastore::SchemaMatch;
 
-use crate::IdentifyArgs;
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Bpaf)]
+#[bpaf(generate(identify_args_inner))]
+#[allow(clippy::struct_excessive_bools)]
+pub struct IdentifyArgs {
+    /// Show detailed schema documentation
+    #[bpaf(long("explain"), switch)]
+    pub explain: bool,
+
+    #[bpaf(long("no-catalog"), switch)]
+    pub no_catalog: bool,
+
+    #[bpaf(long("cache-dir"), argument("DIR"))]
+    pub cache_dir: Option<String>,
+
+    /// Schema cache TTL (e.g. "12h", "30m", "1d"); default 12h
+    #[bpaf(long("schema-cache-ttl"), argument("DURATION"))]
+    pub schema_cache_ttl: Option<String>,
+
+    /// Bypass schema cache reads (still writes fetched schemas to cache)
+    #[bpaf(long("force-schema-fetch"), switch)]
+    pub force_schema_fetch: bool,
+
+    /// Disable syntax highlighting in code blocks
+    #[bpaf(long("no-syntax-highlighting"), switch)]
+    pub no_syntax_highlighting: bool,
+
+    /// Print output directly instead of piping through a pager
+    #[bpaf(long("no-pager"), switch)]
+    pub no_pager: bool,
+
+    /// File to identify
+    #[bpaf(positional("FILE"))]
+    pub file: String,
+}
+
+/// Construct the bpaf parser for `IdentifyArgs`.
+pub fn identify_args() -> impl bpaf::Parser<IdentifyArgs> {
+    identify_args_inner()
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
 
 /// The source that resolved the schema URI for a file.
 #[derive(Debug)]
@@ -59,7 +106,15 @@ impl<'a> From<SchemaMatch<'a>> for CatalogMatchInfo<'a> {
     }
 }
 
-#[allow(clippy::too_many_lines)]
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[allow(
+    clippy::too_many_lines,
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc
+)]
 pub async fn run<C: HttpClient>(
     args: IdentifyArgs,
     global: &CLIGlobalOptions,
@@ -282,7 +337,7 @@ fn pipe_to_pager(content: &str) {
             let _ = child.wait();
         }
         Err(_) => {
-            // Pager unavailable — print directly
+            // Pager unavailable -- print directly
             print!("{content}");
         }
     }
@@ -317,4 +372,76 @@ fn parse_file(
     eprintln!("{path_str}");
     eprintln!("  no schema found (unrecognized format)");
     std::process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bpaf::Parser;
+    use lintel_cli_common::cli_global_options;
+
+    // Helper to build the CLI parser matching the binary's structure.
+    fn test_cli() -> bpaf::OptionParser<(CLIGlobalOptions, IdentifyArgs)> {
+        bpaf::construct!(cli_global_options(), identify_args())
+            .to_options()
+            .descr("test identify args")
+    }
+
+    #[test]
+    fn cli_parses_identify_basic() -> anyhow::Result<()> {
+        let (_, args) = test_cli()
+            .run_inner(&["file.json"])
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        assert_eq!(args.file, "file.json");
+        assert!(!args.explain);
+        assert!(!args.no_catalog);
+        assert!(!args.force_schema_fetch);
+        assert!(args.cache_dir.is_none());
+        assert!(args.schema_cache_ttl.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn cli_parses_identify_explain() -> anyhow::Result<()> {
+        let (_, args) = test_cli()
+            .run_inner(&["file.json", "--explain"])
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        assert_eq!(args.file, "file.json");
+        assert!(args.explain);
+        Ok(())
+    }
+
+    #[test]
+    fn cli_parses_identify_no_catalog() -> anyhow::Result<()> {
+        let (_, args) = test_cli()
+            .run_inner(&["--no-catalog", "file.json"])
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        assert_eq!(args.file, "file.json");
+        assert!(args.no_catalog);
+        Ok(())
+    }
+
+    #[test]
+    fn cli_parses_identify_all_options() -> anyhow::Result<()> {
+        let (_, args) = test_cli()
+            .run_inner(&[
+                "--explain",
+                "--no-catalog",
+                "--force-schema-fetch",
+                "--cache-dir",
+                "/tmp/cache",
+                "--schema-cache-ttl",
+                "30m",
+                "tsconfig.json",
+            ])
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        assert_eq!(args.file, "tsconfig.json");
+        assert!(args.explain);
+        assert!(args.no_catalog);
+        assert!(args.force_schema_fetch);
+        assert_eq!(args.cache_dir.as_deref(), Some("/tmp/cache"));
+        assert_eq!(args.schema_cache_ttl.as_deref(), Some("30m"));
+        Ok(())
+    }
 }

--- a/crates/lintel/Cargo.toml
+++ b/crates/lintel/Cargo.toml
@@ -11,15 +11,12 @@ keywords = ["json-schema", "validation", "yaml", "linter", "cli"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
-jsonschema-explain = { version = "0.1.0", path = "../jsonschema-explain" }
 lintel-annotate = { version = "0.0.3", path = "../lintel-annotate" }
 lintel-check = { version = "0.0.4", path = "../lintel-check" }
 lintel-cli-common = { version = "0.0.1", path = "../lintel-cli-common" }
+lintel-identify = { version = "0.0.1", path = "../lintel-identify" }
 lintel-reporters = { version = "0.0.2", path = "../lintel-reporters" }
-schemastore = { version = "0.0.4", path = "../schemastore" }
 bpaf = { version = "0.9", features = ["autocomplete", "derive", "bright-color"] }
-glob-match = "0.2"
-humantime = "2"
 miette = { version = "7", features = ["fancy"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1"

--- a/crates/lintel/src/commands/mod.rs
+++ b/crates/lintel/src/commands/mod.rs
@@ -1,4 +1,3 @@
 pub mod annotate;
 pub mod convert;
-pub mod identify;
 pub mod init;

--- a/crates/lintel/src/main.rs
+++ b/crates/lintel/src/main.rs
@@ -5,6 +5,7 @@ use lintel_cli_common::CLIGlobalOptions;
 use tracing_subscriber::prelude::*;
 
 use lintel_annotate::annotate_args;
+use lintel_identify::identify_args;
 use lintel_reporters::{ReporterKind, ValidateArgs, make_reporter, validate_args};
 
 mod commands;
@@ -28,40 +29,6 @@ impl core::str::FromStr for OutputFormat {
             )),
         }
     }
-}
-
-#[derive(Debug, Clone, Bpaf)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct IdentifyArgs {
-    /// Show detailed schema documentation
-    #[bpaf(long("explain"), switch)]
-    pub explain: bool,
-
-    #[bpaf(long("no-catalog"), switch)]
-    pub no_catalog: bool,
-
-    #[bpaf(long("cache-dir"), argument("DIR"))]
-    pub cache_dir: Option<String>,
-
-    /// Schema cache TTL (e.g. "12h", "30m", "1d"); default 12h
-    #[bpaf(long("schema-cache-ttl"), argument("DURATION"))]
-    pub schema_cache_ttl: Option<String>,
-
-    /// Bypass schema cache reads (still writes fetched schemas to cache)
-    #[bpaf(long("force-schema-fetch"), switch)]
-    pub force_schema_fetch: bool,
-
-    /// Disable syntax highlighting in code blocks
-    #[bpaf(long("no-syntax-highlighting"), switch)]
-    pub no_syntax_highlighting: bool,
-
-    /// Print output directly instead of piping through a pager
-    #[bpaf(long("no-pager"), switch)]
-    pub no_pager: bool,
-
-    /// File to identify
-    #[bpaf(positional("FILE"))]
-    pub file: String,
 }
 
 #[derive(Debug, Clone, Bpaf)]
@@ -118,7 +85,7 @@ enum Commands {
     /// Show which schema a file resolves to
     Identify(
         #[bpaf(external(lintel_cli_common::cli_global_options), hide_usage)] CLIGlobalOptions,
-        #[bpaf(external(identify_args))] IdentifyArgs,
+        #[bpaf(external(identify_args))] lintel_identify::IdentifyArgs,
     ),
 
     #[bpaf(command("init"))]
@@ -221,7 +188,7 @@ async fn main() -> ExitCode {
         Commands::Identify(global, args) => {
             setup_tracing(&global);
             setup_miette(&global);
-            commands::identify::run(
+            lintel_identify::run(
                 args,
                 &global,
                 lintel_check::retriever::ReqwestClient::default(),
@@ -372,35 +339,6 @@ mod tests {
     }
 
     #[test]
-    fn cli_verbose_short_after_subcommand() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&["check", "-v", "*.json"])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Check(global, _, args) => {
-                assert!(global.verbose);
-                assert_eq!(args.globs, vec!["*.json"]);
-            }
-            _ => panic!("expected Check"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn cli_verbose_long_after_subcommand() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&["check", "--verbose"])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Check(global, _, _) => {
-                assert!(global.verbose);
-            }
-            _ => panic!("expected Check"),
-        }
-        Ok(())
-    }
-
-    #[test]
     fn cli_check_default_reporter_is_pretty() -> anyhow::Result<()> {
         let parsed = cli()
             .run_inner(&["check"])
@@ -452,112 +390,6 @@ mod tests {
                 assert_eq!(reporter_kind, ReporterKind::Pretty);
             }
             _ => panic!("expected CI"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn cli_parses_identify_basic() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&["identify", "file.json"])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Identify(_, args) => {
-                assert_eq!(args.file, "file.json");
-                assert!(!args.explain);
-                assert!(!args.no_catalog);
-                assert!(!args.force_schema_fetch);
-                assert!(args.cache_dir.is_none());
-                assert!(args.schema_cache_ttl.is_none());
-            }
-            _ => panic!("expected Identify"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn cli_check_with_log_level() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&["check", "--log-level", "debug"])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Check(global, _, _) => {
-                assert_eq!(global.log_level, lintel_cli_common::LogLevel::Debug);
-            }
-            _ => panic!("expected Check"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn cli_check_with_colors_off() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&["check", "--colors", "off"])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Check(global, _, _) => {
-                assert_eq!(global.colors, Some(lintel_cli_common::ColorsArg::Off));
-            }
-            _ => panic!("expected Check"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn cli_parses_identify_explain() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&["identify", "file.json", "--explain"])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Identify(_, args) => {
-                assert_eq!(args.file, "file.json");
-                assert!(args.explain);
-            }
-            _ => panic!("expected Identify"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn cli_parses_identify_no_catalog() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&["identify", "--no-catalog", "file.json"])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Identify(_, args) => {
-                assert_eq!(args.file, "file.json");
-                assert!(args.no_catalog);
-            }
-            _ => panic!("expected Identify"),
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn cli_parses_identify_all_options() -> anyhow::Result<()> {
-        let parsed = cli()
-            .run_inner(&[
-                "identify",
-                "--explain",
-                "--no-catalog",
-                "--force-schema-fetch",
-                "--cache-dir",
-                "/tmp/cache",
-                "--schema-cache-ttl",
-                "30m",
-                "tsconfig.json",
-            ])
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-        match parsed.command {
-            Commands::Identify(_, args) => {
-                assert_eq!(args.file, "tsconfig.json");
-                assert!(args.explain);
-                assert!(args.no_catalog);
-                assert!(args.force_schema_fetch);
-                assert_eq!(args.cache_dir.as_deref(), Some("/tmp/cache"));
-                assert_eq!(args.schema_cache_ttl.as_deref(), Some("30m"));
-            }
-            _ => panic!("expected Identify"),
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Extract the `identify` command's args (`IdentifyArgs`), execution logic, and CLI parsing tests from the `lintel` binary crate into a new `lintel-identify` library crate, following the same pattern as `lintel-annotate`
- Move identify-only dependencies (`jsonschema-explain`, `glob-match`, `schemastore`, `humantime`) out of the `lintel` binary and into `lintel-identify`
- Add unit tests for `lintel-cli-common` global options (verbose, log-level, colors)

## Test plan
- [x] `cargo test -p lintel-identify` — 4 CLI parsing tests pass
- [x] `cargo test -p lintel` — 9 remaining binary tests pass
- [x] `cargo clippy --workspace` — clean