### PR TITLE
fix: add missing dependencies to lintel crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,8 @@ version = "0.0.3"
 dependencies = [
  "anyhow",
  "bpaf",
+ "glob-match",
+ "humantime",
  "insta",
  "lintel-annotate",
  "lintel-check",
@@ -1245,6 +1247,7 @@ dependencies = [
  "lintel-identify",
  "lintel-reporters",
  "miette",
+ "schemastore",
  "serde_json",
  "serde_yaml",
  "tokio",

--- a/crates/lintel/Cargo.toml
+++ b/crates/lintel/Cargo.toml
@@ -16,7 +16,10 @@ lintel-check = { version = "0.0.4", path = "../lintel-check" }
 lintel-cli-common = { version = "0.0.1", path = "../lintel-cli-common" }
 lintel-identify = { version = "0.0.1", path = "../lintel-identify" }
 lintel-reporters = { version = "0.0.2", path = "../lintel-reporters" }
+schemastore = { version = "0.0.4", path = "../schemastore" }
 bpaf = { version = "0.9", features = ["autocomplete", "derive", "bright-color"] }
+glob-match = "0.2"
+humantime = "2"
 miette = { version = "7", features = ["fancy"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1"


### PR DESCRIPTION
## Summary
- Add `humantime`, `glob-match`, and `schemastore` dependencies to `crates/lintel/Cargo.toml`
- These are used by the `cache` subcommand (`src/commands/cache.rs`) but were not declared, causing build failures

## Test plan
- [x] `cargo check` passes