### PR TITLE
chore: standardize crate metadata and READMEs

### DIFF
--- a/crates/lintel-catalog-builder/README.md
+++ b/crates/lintel-catalog-builder/README.md
@@ -1,6 +1,13 @@
 # lintel-catalog-builder
 
+[![Crates.io](https://img.shields.io/crates/v/lintel-catalog-builder.svg)](https://crates.io/crates/lintel-catalog-builder)
+[![docs.rs](https://docs.rs/lintel-catalog-builder/badge.svg)](https://docs.rs/lintel-catalog-builder)
+[![CI](https://github.com/lintel-rs/lintel/actions/workflows/ci.yml/badge.svg)](https://github.com/lintel-rs/lintel/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/lintel-catalog-builder.svg)](https://github.com/lintel-rs/lintel/blob/master/LICENSE)
+
 Build a custom JSON Schema catalog from local schemas and external sources like [SchemaStore](https://www.schemastore.org/).
+
+Part of the [Lintel](https://github.com/lintel-rs/lintel) project.
 
 ## Config format
 
@@ -151,3 +158,7 @@ Go to repo **Settings > Pages > Source** and select **GitHub Actions**.
 ### 4. Configure DNS (if using a custom domain)
 
 Create a CNAME DNS record pointing your domain to `<your-org>.github.io`. The `CNAME` file in the generated output tells GitHub Pages to use the custom domain automatically.
+
+## License
+
+Apache-2.0

--- a/crates/lintel-catalog-builder/src/main.rs
+++ b/crates/lintel-catalog-builder/src/main.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 extern crate alloc;
 
 use std::path::PathBuf;

--- a/crates/schema-catalog/Cargo.toml
+++ b/crates/schema-catalog/Cargo.toml
@@ -7,6 +7,8 @@ description = "Types for the JSON Schema catalog format (schema-catalog.json)"
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+keywords = ["json-schema", "catalog", "schemastore"]
+categories = ["data-structures"]
 
 [lints]
 workspace = true

--- a/crates/schema-catalog/README.md
+++ b/crates/schema-catalog/README.md
@@ -1,0 +1,24 @@
+# schema-catalog
+
+[![Crates.io](https://img.shields.io/crates/v/schema-catalog.svg)](https://crates.io/crates/schema-catalog)
+[![docs.rs](https://docs.rs/schema-catalog/badge.svg)](https://docs.rs/schema-catalog)
+[![CI](https://github.com/lintel-rs/lintel/actions/workflows/ci.yml/badge.svg)](https://github.com/lintel-rs/lintel/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/schema-catalog.svg)](https://github.com/lintel-rs/lintel/blob/master/LICENSE)
+
+Types for the JSON Schema catalog format (`schema-catalog.json`), compatible with [SchemaStore](https://www.schemastore.org/).
+
+Part of the [Lintel](https://github.com/lintel-rs/lintel) project.
+
+## Usage
+
+```rust
+use schema_catalog::{Catalog, parse_catalog};
+
+let json = r#"{"version":1,"schemas":[{"name":"Example","description":"An example schema","url":"https://example.com/schema.json","fileMatch":["*.example.json"]}]}"#;
+let catalog: Catalog = parse_catalog(json).unwrap();
+assert_eq!(catalog.schemas[0].name, "Example");
+```
+
+## License
+
+Apache-2.0

--- a/crates/schema-catalog/src/lib.rs
+++ b/crates/schema-catalog/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 extern crate alloc;
 
 use alloc::collections::BTreeMap;


### PR DESCRIPTION
## Summary
- Add crates.io, docs.rs, CI, and license badges plus a license section to `lintel-catalog-builder` README
- Add `keywords`, `categories`, and a new README with usage example to `schema-catalog`
- Include `#![doc = include_str!("../README.md")]` in both crates for docs.rs

## Test plan
- [x] `cargo-furnish check` reports zero issues across all 19 crates