### PR TITLE
fix: add regex-fancy feature to sublime-syntaxes runtime dep

### DIFF
--- a/crates/sublime-syntaxes/Cargo.toml
+++ b/crates/sublime-syntaxes/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["text-processing"]
 workspace = true
 
 [dependencies]
-syntect = { version = "5", default-features = false, features = ["default-syntaxes"] }
+syntect = { version = "5", default-features = false, features = ["default-syntaxes", "regex-fancy"] }
 
 [build-dependencies]
 syntect = { version = "5", default-features = false, features = [


### PR DESCRIPTION
## Summary
- Added `regex-fancy` feature to sublime-syntaxes' runtime `[dependencies]` for syntect
- The feature was already present in `[build-dependencies]` and in `markdown-to-ansi`, but missing from the runtime dep
- This caused `cargo publish --verify` to fail because syntect's `regex_impl` module requires either `regex-fancy` or `regex-onig`

## Test plan
- [x] `cargo check -p sublime-syntaxes` passes
- [x] `cargo publish -p sublime-syntaxes --dry-run --allow-dirty` passes verification build