### PR TITLE
feat: update all dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1200,7 +1199,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest 0.13.2",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",
@@ -1272,7 +1271,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio",
- "toml 1.0.3+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -1313,13 +1312,13 @@ dependencies = [
  "glob-match",
  "lintel-schema-cache",
  "percent-encoding",
- "reqwest 0.12.28",
+ "reqwest",
  "schema-catalog",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -1348,7 +1347,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml 1.0.3+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -1369,7 +1368,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml 1.0.3+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -1380,7 +1379,7 @@ dependencies = [
  "bpaf",
  "lintel-check",
  "lintel-reporters",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -1422,7 +1421,7 @@ dependencies = [
  "dirs",
  "filetime",
  "jsonschema",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "sha2",
  "tempfile",
@@ -1437,7 +1436,7 @@ dependencies = [
  "anyhow",
  "bpaf",
  "futures",
- "reqwest 0.12.28",
+ "reqwest",
  "schemastore",
  "serde_json",
  "tempfile",
@@ -1873,6 +1872,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2043,44 +2043,6 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2101,6 +2063,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2165,7 +2128,6 @@ checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2399,32 +2361,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -2793,38 +2734,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.0.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2838,15 +2758,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -2858,12 +2777,6 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3268,15 +3181,6 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/cargo-furnish/Cargo.toml
+++ b/crates/cargo-furnish/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities", "development-tools"]
 workspace = true
 
 [dependencies]
-toml_edit = "0.22"
+toml_edit = "0.25"
 bpaf = { version = "0.9", features = ["derive", "bright-color"] }
 anyhow = "1"
 miette = { version = "7", features = ["fancy"] }

--- a/crates/lintel-catalog-builder/Cargo.toml
+++ b/crates/lintel-catalog-builder/Cargo.toml
@@ -18,10 +18,10 @@ schema-catalog = { version = "0.0.1", path = "../schema-catalog" }
 lintel-schema-cache = { version = "0.0.6", path = "../lintel-schema-cache" }
 bpaf = { version = "0.9", features = ["derive", "bright-color"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "process"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-toml = "0.8"
+toml = "1.0"
 anyhow = "1"
 futures = "0.3"
 tracing = "0.1"

--- a/crates/lintel-github-action/Cargo.toml
+++ b/crates/lintel-github-action/Cargo.toml
@@ -19,6 +19,6 @@ lintel-reporters = { version = "0.0.4", path = "../lintel-reporters" }
 bpaf = { version = "0.9", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/lintel-schema-cache/Cargo.toml
+++ b/crates/lintel-schema-cache/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 jsonschema = { version = "0.42", features = ["resolve-async"] }
 tokio = { version = "1", features = ["rt", "fs"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde_json = "1"
 async-trait = "0.1"
 sha2 = "0.10"

--- a/crates/lintel-schemastore-catalog/Cargo.toml
+++ b/crates/lintel-schemastore-catalog/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 schemastore = { version = "0.0.5", path = "../schemastore" }
 bpaf = { version = "0.9", features = ["derive", "bright-color"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde_json = "1"
 anyhow = "1"
 futures = "0.3"


### PR DESCRIPTION
## Summary
- Bump `reqwest` 0.12 → 0.13 (lintel-catalog-builder, lintel-github-action, lintel-schema-cache, lintel-schemastore-catalog)
- Bump `toml` 0.8 → 1.0 (lintel-catalog-builder)
- Bump `toml_edit` 0.22 → 0.25 (cargo-furnish)
- Rename `rustls-tls` feature to `rustls` for reqwest 0.13 compatibility

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets` passes with no warnings
- [x] `cargo test` — all 306 tests pass