### PR TITLE
Add npm provenance support to release workflow

### DIFF
--- a/.github/workflows/release-lintel.yml
+++ b/.github/workflows/release-lintel.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 env:
   REGISTRY: ghcr.io
@@ -154,7 +155,8 @@ jobs:
         run: |
           cargo run --release --package npm-release-binaries -- release \
             --package lintel \
-            --release-version ${{ inputs.version }}
+            --release-version ${{ inputs.version }} \
+            --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/crates/npm-release-binaries/src/commands/release.rs
+++ b/crates/npm-release-binaries/src/commands/release.rs
@@ -1,7 +1,11 @@
 use super::generate;
+use super::publish;
 
-pub fn run(opts: &generate::Options<'_>) -> miette::Result<()> {
+pub fn run(
+    opts: &generate::Options<'_>,
+    publish_opts: &publish::Options<'_>,
+) -> miette::Result<()> {
     generate::run(opts)?;
-    super::publish::run(opts.pkg_config, opts.output_dir, false)?;
+    super::publish::run(opts.pkg_config, opts.output_dir, publish_opts)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add optional `--provenance` flag to `release` and `publish` CLI commands in `npm-release-binaries`
- Enable `id-token: write` permission in the release workflow for OIDC-based provenance signing
- Pass `--provenance` in the CI release invocation so published npm packages include signed provenance attestations

## Test plan
- [x] `cargo clippy --package npm-release-binaries` passes
- [ ] Trigger a release and verify npm publish succeeds with provenance
- [ ] Verify published packages show provenance badge on npmjs.com