### PR TITLE
docs: update README with @lintel/lintel npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@
 cargo install lintel
 ```
 
-Or with npm:
+Or with [npm](https://www.npmjs.com/package/@lintel/lintel):
 
 ```shell
 npx @lintel/lintel check
+bunx @lintel/lintel check
+pnpx @lintel/lintel check
 ```
 
 Or with Nix:


### PR DESCRIPTION
## Summary
- Add npm version badge linking to `@lintel/lintel` on npmjs.com
- Update `npx` command from `npx lintel check` to `npx @lintel/lintel check` to use the correct scoped package name

## Test plan
- [ ] Verify npm badge renders correctly on the README
- [ ] Verify `npx @lintel/lintel check` works as expected