### PR TITLE
fix: render markdown headers properly in descriptions

### DIFF
--- a/crates/markdown-to-ansi/src/render.rs
+++ b/crates/markdown-to-ansi/src/render.rs
@@ -71,10 +71,12 @@ pub(crate) fn render_events<'a>(
             }
 
             Event::Start(Tag::Heading { .. }) => {
-                out.push_str(BOLD);
+                flush_text(&mut out, &mut st, opts.width);
+                st.text_buf.push_str(BOLD);
             }
             Event::End(TagEnd::Heading(_)) => {
-                out.push_str(RESET);
+                st.text_buf.push_str(RESET);
+                flush_text(&mut out, &mut st, opts.width);
                 out.push('\n');
             }
 


### PR DESCRIPTION
## Summary

- Fix markdown headers (e.g. `## Access method`) in schema descriptions being rendered incorrectly — heading text was concatenating with the following paragraph instead of appearing on its own line
- Root cause: `BOLD`/`RESET` ANSI codes were pushed directly to the output buffer while heading text accumulated in `text_buf`, so the codes appeared on an empty line and the heading text merged with the next paragraph
- Fix: push `BOLD`/`RESET` into `text_buf` alongside the heading text and call `flush_text` at heading end

## Test plan

- [x] `cargo test -p markdown-to-ansi` — all 27 tests pass
- [x] `cargo test -p jsonschema-explain` — all 40 tests pass
- [x] Verified with `lintel explain --schema catalog/schemas/ads/sellers.json` — `## Access method`, `## Caching`, and `## Standard identifier names` headers now render correctly as bold text on their own lines