### PR TITLE
Add examples rendering and compact array type syntax

### DIFF
--- a/crates/jsonschema-explain/src/fmt.rs
+++ b/crates/jsonschema-explain/src/fmt.rs
@@ -77,7 +77,7 @@ impl Fmt<'_> {
 /// Format a type string with color.
 ///
 /// Splits on ` | ` to colorize each alternative, and handles
-/// compound types like `array of string`.
+/// compound types like `string[]`.
 pub(crate) fn format_type(ty: &str, f: &Fmt<'_>) -> String {
     if ty.is_empty() {
         return String::new();
@@ -88,15 +88,8 @@ pub(crate) fn format_type(ty: &str, f: &Fmt<'_>) -> String {
             .map(|p| format!("{}{p}{}", f.cyan, f.reset))
             .collect::<Vec<_>>()
             .join(&separator)
-    } else if let Some(rest) = ty.strip_prefix("array of ") {
-        format!(
-            "{}array{} {}of{} {}",
-            f.cyan,
-            f.reset,
-            f.dim,
-            f.reset,
-            format_type(rest, f)
-        )
+    } else if let Some(rest) = ty.strip_suffix("[]") {
+        format!("{}{}[]{}", format_type(rest, f), f.cyan, f.reset)
     } else {
         format!("{}{ty}{}", f.cyan, f.reset)
     }

--- a/crates/jsonschema-explain/src/render.rs
+++ b/crates/jsonschema-explain/src/render.rs
@@ -148,6 +148,20 @@ fn render_property_details(
         );
     }
 
+    if let Some(examples) = prop_schema.get("examples").and_then(Value::as_array)
+        && !examples.is_empty()
+    {
+        let joined: String = examples
+            .iter()
+            .map(|v| {
+                let display = format_value(v);
+                format!("{}{display}{}", f.magenta, f.reset)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        write_label(out, desc_indent, "Examples", &joined);
+    }
+
     for keyword in COMPOSITION_KEYWORDS {
         if let Some(variants) = prop_schema.get(*keyword).and_then(Value::as_array) {
             let label = match *keyword {
@@ -170,16 +184,6 @@ fn render_property_details(
         let nested_required = required_set(prop_schema);
         out.push('\n');
         render_properties(out, nested_props, &nested_required, root, f, depth + 1);
-    }
-
-    if prop_schema.get("type").and_then(Value::as_str) == Some("array")
-        && let Some(items) = prop_schema.get("items")
-    {
-        let items = resolve_ref(items, root);
-        let item_ty = schema_type_str(items).unwrap_or_default();
-        if !item_ty.is_empty() {
-            write_label(out, desc_indent, "Items", &format_type(&item_ty, f));
-        }
     }
 }
 

--- a/crates/jsonschema-explain/src/schema.rs
+++ b/crates/jsonschema-explain/src/schema.rs
@@ -101,7 +101,7 @@ pub(crate) fn schema_type_str(schema: &Value) -> Option<String> {
         return match ty {
             Value::String(s) if s == "array" => match schema.get("items").and_then(schema_type_str)
             {
-                Some(item_ty) => Some(format!("array of {item_ty}")),
+                Some(item_ty) => Some(format!("{item_ty}[]")),
                 None => Some("array".to_string()),
             },
             Value::String(s) => Some(s.clone()),


### PR DESCRIPTION
## Summary
- Render JSON Schema `examples` keyword on properties (e.g. `Examples: "TAG-ID", "DUNS"`)
- Render top-level `EXAMPLES` section with syntax-highlighted JSON for complex values
- Change array type display from `array of X` to `X[]` with full colorization
- Remove redundant `Items: <type>` line from array properties since the item type is now shown inline

## Test plan
- [x] All 43 existing + 3 new unit tests pass
- [ ] Run `lintel explain --schema https://catalog.lintel.tools/schemas/ads/sellers.json` and verify:
  - `sellers (Seller[], *required)` instead of `sellers (array of Seller, *required)`
  - `Examples: "TAG-ID", "DUNS"` on `Identifier.name`
  - `EXAMPLES` section at root with formatted JSON
  - No `Items: object` lines