### PR TITLE
fix: use boolean for force param in action release workflow

### DIFF
--- a/.github/workflows/release-lintel-github-action.yml
+++ b/.github/workflows/release-lintel-github-action.yml
@@ -58,6 +58,6 @@ jobs:
           MAJOR="v$(echo "${{ inputs.version }}" | cut -d. -f1)"
           SHA=$(gh api repos/lintel-rs/action/git/ref/tags/lintel-github-action-v${{ inputs.version }} --jq .object.sha)
           gh api repos/lintel-rs/action/git/refs/tags/${MAJOR} \
-            -X PATCH -f sha="$SHA" -f force=true 2>/dev/null \
+            -X PATCH -f sha="$SHA" -F force=true 2>/dev/null \
           || gh api repos/lintel-rs/action/git/refs \
             -X POST -f ref="refs/tags/${MAJOR}" -f sha="$SHA"


### PR DESCRIPTION
## Summary
- Fixed `-f force=true` → `-F force=true` in the major version tag update step of the GitHub Action release workflow
- The `gh api` `-f` flag passes values as strings, but the GitHub API `PATCH /git/refs` endpoint expects `force` as a boolean — `-F` sends proper typed values
- Without this fix, releasing a new action version would fail to move the `v0` major version tag forward

## Context
- Also created the missing `v0` tag in `lintel-rs/action` (pointing to same commit as `v0.0.1`) to unblock `lintel-rs/catalog` CI which references `lintel-rs/action@v0`

## Test plan
- [ ] Verify `lintel-rs/catalog` CI passes now that `v0` tag exists
- [ ] On next action release, confirm the `v0` tag is properly updated