### PR TITLE
Add catalog.json schema, rename outputs, auto-populate metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
  "bpaf",
  "lintel-catalog-builder",
  "lintel-config",
+ "schema-catalog",
  "serde_json",
 ]
 
@@ -2317,6 +2318,7 @@ dependencies = [
 name = "schema-catalog"
 version = "0.0.2"
 dependencies = [
+ "schemars",
  "serde",
  "serde_json",
 ]

--- a/crates/lintel-catalog-builder/src/config.rs
+++ b/crates/lintel-catalog-builder/src/config.rs
@@ -153,6 +153,11 @@ pub struct GroupConfig {
 ///
 /// Defines where to obtain the schema, its display metadata, and which files it
 /// should match in the catalog.
+///
+/// The `name` and `description` fields are optional overrides. When omitted,
+/// they are auto-populated from the underlying JSON Schema's `title` and
+/// `description` properties. If the schema has no title, the entry key is used
+/// as a fallback name.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[schemars(title = "Schema Definition")]
@@ -163,10 +168,16 @@ pub struct SchemaDefinition {
     /// `schemas/<group>/<key>.json`.
     pub url: Option<String>,
     /// Human-readable display name for this schema.
+    ///
+    /// When omitted, defaults to the `title` property from the JSON Schema.
     #[schemars(example = &"GitHub Workflow", example = &"devenv.yaml")]
-    pub name: String,
+    #[serde(default)]
+    pub name: Option<String>,
     /// Short description of what this schema validates.
-    pub description: String,
+    ///
+    /// When omitted, defaults to the `description` property from the JSON Schema.
+    #[serde(default)]
+    pub description: Option<String>,
     /// Glob patterns for files this schema should be auto-associated with.
     ///
     /// Editors and tools use these patterns to automatically apply the schema
@@ -322,7 +333,10 @@ match = ["**.github**"]
         let claude_code = &config.groups["claude-code"];
         assert_eq!(claude_code.name, "Claude Code");
         assert_eq!(claude_code.schemas.len(), 2);
-        assert_eq!(claude_code.schemas["agent"].name, "Claude Code Agent");
+        assert_eq!(
+            claude_code.schemas["agent"].name.as_deref(),
+            Some("Claude Code Agent")
+        );
         assert!(claude_code.schemas["agent"].url.is_none());
         assert_eq!(
             claude_code.schemas["agent"].file_match,

--- a/crates/lintel-config-schema-generator/Cargo.toml
+++ b/crates/lintel-config-schema-generator/Cargo.toml
@@ -16,5 +16,6 @@ workspace = true
 [dependencies]
 lintel-config = { version = "0.0.4", path = "../lintel-config" }
 lintel-catalog-builder = { version = "0.0.5", path = "../lintel-catalog-builder" }
+schema-catalog = { version = "0.0.2", path = "../schema-catalog" }
 bpaf = { version = "0.9", features = ["derive"] }
 serde_json = "1"

--- a/crates/lintel-config-schema-generator/src/main.rs
+++ b/crates/lintel-config-schema-generator/src/main.rs
@@ -17,11 +17,12 @@ fn main() {
     std::fs::create_dir_all(&cli.output_dir).expect("failed to create output directory");
 
     let configs: &[(&str, serde_json::Value)] = &[
-        ("lintel.json", lintel_config::schema()),
+        ("lintel-toml.json", lintel_config::schema()),
         (
-            "lintel-catalog.json",
+            "lintel-catalog-toml.json",
             lintel_catalog_builder::config::schema(),
         ),
+        ("catalog.json", schema_catalog::schema()),
     ];
 
     for (filename, schema) in configs {

--- a/crates/schema-catalog/Cargo.toml
+++ b/crates/schema-catalog/Cargo.toml
@@ -14,5 +14,6 @@ categories = ["data-structures"]
 workspace = true
 
 [dependencies]
+schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/schema-catalog/src/lib.rs
+++ b/crates/schema-catalog/src/lib.rs
@@ -4,16 +4,30 @@ extern crate alloc;
 
 use alloc::collections::BTreeMap;
 
+use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-/// A JSON Schema catalog following the `SchemaStore` catalog format.
+/// Schema catalog index that maps file patterns to JSON Schema URLs.
+///
+/// A catalog is a collection of schema entries used by editors and tools to
+/// automatically associate files with the correct schema for validation and
+/// completion. Follows the `SchemaStore` catalog format.
+///
 /// See: <https://json.schemastore.org/schema-catalog.json>
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "catalog.json")]
 pub struct Catalog {
+    /// The catalog format version. Currently always `1`.
     pub version: u32,
+    /// An optional human-readable title for the catalog.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// The list of schema entries in this catalog.
     pub schemas: Vec<SchemaEntry>,
+    /// Optional grouping of related schemas for catalog consumers that
+    /// support richer organization. Consumers that don't understand
+    /// `groups` simply ignore this field.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub groups: Vec<CatalogGroup>,
 }
@@ -22,26 +36,68 @@ pub struct Catalog {
 ///
 /// Groups provide richer metadata for catalog consumers that support them.
 /// Consumers that don't understand `groups` simply ignore the field.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "Schema Group")]
 pub struct CatalogGroup {
+    /// The display name for this group.
     pub name: String,
+    /// A short description of the schemas in this group.
     pub description: String,
     /// Schema names that belong to this group.
     pub schemas: Vec<String>,
 }
 
 /// A single schema entry in the catalog.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Each entry maps a schema to its URL and the file patterns it applies to.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "Schema Entry")]
 pub struct SchemaEntry {
+    /// The display name of the schema.
+    #[schemars(example = example_schema_name())]
     pub name: String,
+    /// A short description of what the schema validates.
     pub description: String,
+    /// The URL where the schema can be fetched.
+    #[schemars(example = example_schema_url())]
     pub url: String,
+    /// An optional URL pointing to the upstream or canonical source of
+    /// the schema (e.g. a GitHub raw URL).
     #[serde(default, rename = "sourceUrl", skip_serializing_if = "Option::is_none")]
     pub source_url: Option<String>,
+    /// Glob patterns for files this schema should be applied to.
+    ///
+    /// Editors and tools use these patterns to automatically associate
+    /// matching files with this schema.
     #[serde(default, rename = "fileMatch", skip_serializing_if = "Vec::is_empty")]
+    #[schemars(title = "File Match")]
+    #[schemars(example = example_file_match())]
     pub file_match: Vec<String>,
+    /// Alternate versions of this schema, keyed by version identifier.
+    /// Values are URLs to the versioned schema.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub versions: BTreeMap<String, String>,
+}
+
+fn example_schema_name() -> String {
+    "My Config".to_owned()
+}
+
+fn example_schema_url() -> String {
+    "https://example.com/schemas/my-config.json".to_owned()
+}
+
+fn example_file_match() -> Vec<String> {
+    vec!["*.config.json".to_owned(), "**/.config.json".to_owned()]
+}
+
+/// Generate the JSON Schema for the [`Catalog`] type.
+///
+/// # Panics
+///
+/// Panics if the schema cannot be serialized to JSON (should never happen).
+pub fn schema() -> Value {
+    serde_json::to_value(schema_for!(Catalog)).expect("schema serialization cannot fail")
 }
 
 /// Parse a catalog from a JSON string.
@@ -151,6 +207,20 @@ mod tests {
         assert_eq!(
             catalog.schemas[0].versions.get("draft-07"),
             Some(&"https://example.com/draft07.json".to_string())
+        );
+    }
+
+    #[test]
+    fn schema_has_camel_case_properties() {
+        let schema = schema();
+        let schema_str = serde_json::to_string(&schema).expect("serialize");
+        assert!(
+            schema_str.contains("fileMatch"),
+            "schema should contain fileMatch"
+        );
+        assert!(
+            schema_str.contains("sourceUrl"),
+            "schema should contain sourceUrl"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Rename schema generator outputs from `lintel.json`/`lintel-catalog.json` to `lintel-toml.json`/`lintel-catalog-toml.json` for clearer naming
- Add third generated schema `catalog.json` for the `schema-catalog` crate's `Catalog` type, with `JsonSchema` derives, titles, descriptions, and examples on all types and fields
- Make `SchemaDefinition.name` and `SchemaDefinition.description` optional — when omitted, they are auto-populated from the underlying JSON Schema's `title` and `description` properties

## Test plan

- [x] `cargo clippy --workspace` passes
- [x] `cargo test --workspace` passes
- [x] All three schemas generated to `catalog/schemas/lintel/`
- [x] `catalog.json` schema uses camelCase properties (`fileMatch`, `sourceUrl`)
- [x] Renamed files have correct content