### PR TITLE
Add publish=false check to cargo furnish

### DIFF
--- a/crates/npm-release-binaries/Cargo.toml
+++ b/crates/npm-release-binaries/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 homepage.workspace = true
 keywords = ["npm", "release", "binary", "cli"]
 categories = ["command-line-utilities"]
-publish = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Add `furnish::publish_false` diagnostic that warns when `publish = false` is set in `[package]`
- Auto-remove the field with `cargo furnish check --fix`
- Fix the one existing occurrence in `npm-release-binaries`

## Test plan
- [x] `cargo furnish check npm-release-binaries` correctly reports the diagnostic on line 12
- [x] `cargo furnish check --fix npm-release-binaries` removes `publish = false`
- [x] Re-running check after fix reports no issues
- [x] Clippy passes