### PR TITLE
Remove invalid cargo_package_args from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,3 @@
 [[package]]
 name = "lintel"
 git_tag_name = "v{{ version }}"
-
-[[package]]
-name = "lintel-config-schema-generator"
-cargo_package_args = ["--no-verify"]


### PR DESCRIPTION
## Summary
- Removes the `lintel-config-schema-generator` package entry from `release-plz.toml` which used the invalid `cargo_package_args` field, causing CI failures.

## Test plan
- [ ] Verify release-plz CI workflow passes on master after merge