### PR TITLE
Make schema-catalog no_std and replace futures with futures-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ version = "0.0.6"
 dependencies = [
  "anyhow",
  "bpaf",
- "futures",
+ "futures-util",
  "glob-match",
  "lintel-schema-cache",
  "percent-encoding",
@@ -1480,7 +1480,7 @@ version = "0.0.9"
 dependencies = [
  "anyhow",
  "bpaf",
- "futures",
+ "futures-util",
  "reqwest",
  "schemastore",
  "serde_json",

--- a/crates/lintel-catalog-builder/Cargo.toml
+++ b/crates/lintel-catalog-builder/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 schemars = "1"
 toml = "1.0"
 anyhow = "1"
-futures = "0.3"
+futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-tree = "0.4"

--- a/crates/lintel-catalog-builder/src/download.rs
+++ b/crates/lintel-catalog-builder/src/download.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::Result;
-use futures::stream::{self, StreamExt};
+use futures_util::stream::{self, StreamExt};
 use lintel_schema_cache::{CacheStatus, SchemaCache};
 use tracing::{info, warn};
 

--- a/crates/lintel-schemastore-catalog/Cargo.toml
+++ b/crates/lintel-schemastore-catalog/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde_json = "1"
 anyhow = "1"
-futures = "0.3"
+futures-util = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-tree = "0.4"

--- a/crates/lintel-schemastore-catalog/src/download.rs
+++ b/crates/lintel-schemastore-catalog/src/download.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use futures::stream::{self, StreamExt};
+use futures_util::stream::{self, StreamExt};
 use tracing::{debug, warn};
 
 /// Maximum schema file size we'll download (10 MiB). Schemas larger than this

--- a/crates/schema-catalog/Cargo.toml
+++ b/crates/schema-catalog/Cargo.toml
@@ -14,6 +14,6 @@ categories = ["data-structures"]
 workspace = true
 
 [dependencies]
-schemars = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+schemars = { version = "1", default-features = false, features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+serde_json = { version = "1", default-features = false, features = ["alloc"] }

--- a/crates/schema-catalog/src/lib.rs
+++ b/crates/schema-catalog/src/lib.rs
@@ -1,8 +1,13 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
 
 extern crate alloc;
 
+use alloc::borrow::ToOwned;
 use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
@@ -120,6 +125,8 @@ pub fn parse_catalog_value(value: serde_json::Value) -> Result<Catalog, serde_js
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Summary
- Make the `schema-catalog` crate `no_std` compatible by disabling default features on `schemars`, `serde`, and `serde_json` dependencies and adding explicit `alloc` imports
- Replace the full `futures` crate with the lighter `futures-util` in `lintel-catalog-builder` and `lintel-schemastore-catalog`

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Verify `cargo test` passes for all affected crates
- [ ] Verify `cargo publish --dry-run` works for `schema-catalog`