### PR TITLE
Change dependabot schedule from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily


### PR DESCRIPTION
## Summary
- Update dependabot schedule interval from weekly to daily for both cargo and github-actions ecosystems

## Test plan
- [ ] Verify dependabot runs daily after merge