### PR TITLE
Skip nix build on pull requests

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,7 +3,6 @@ name: Nix
 on:
   push:
     branches: [master]
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Remove `pull_request` trigger from the Nix workflow so it only runs on pushes to master
- The nix build is slow and not needed for PR validation — cargo CI covers correctness

## Test plan

- [ ] Verify nix workflow no longer triggers on PRs
- [ ] Confirm it still runs on pushes to master