### PR TITLE
Parse .json files as JSONC

### DIFF
--- a/crates/lintel-validate/src/parsers/mod.rs
+++ b/crates/lintel-validate/src/parsers/mod.rs
@@ -70,10 +70,9 @@ pub trait Parser {
 /// Detect file format from extension. Returns `None` for unrecognized extensions.
 pub fn detect_format(path: &Path) -> Option<FileFormat> {
     match path.extension().and_then(|e| e.to_str()) {
-        Some("json") => Some(FileFormat::Json),
         Some("yaml" | "yml") => Some(FileFormat::Yaml),
         Some("json5") => Some(FileFormat::Json5),
-        Some("jsonc") => Some(FileFormat::Jsonc),
+        Some("json" | "jsonc") => Some(FileFormat::Jsonc),
         Some("toml") => Some(FileFormat::Toml),
         Some("md" | "mdx") => Some(FileFormat::Markdown),
         _ => None,
@@ -246,7 +245,10 @@ mod tests {
 
     #[test]
     fn detect_format_json() {
-        assert_eq!(detect_format(Path::new("foo.json")), Some(FileFormat::Json));
+        assert_eq!(
+            detect_format(Path::new("foo.json")),
+            Some(FileFormat::Jsonc)
+        );
     }
 
     #[test]

--- a/crates/lintel-validate/src/validate.rs
+++ b/crates/lintel-validate/src/validate.rs
@@ -14,7 +14,7 @@ use schemastore::CompiledCatalog;
 
 use crate::diagnostics::{DEFAULT_LABEL, find_instance_path_span, format_label};
 use crate::discover;
-use crate::parsers::{self, FileFormat, JsoncParser, Parser};
+use crate::parsers::{self, Parser};
 use crate::registry;
 
 /// Conservative limit for concurrent file reads to avoid exhausting file
@@ -227,21 +227,7 @@ fn process_one_file(
         let parser = parsers::parser_for(fmt);
         match parser.parse(&content, &path_str) {
             Ok(val) => (parser, val),
-            Err(parse_err) => {
-                // JSONC fallback for .json files that match a catalog entry.
-                if fmt == FileFormat::Json
-                    && compiled_catalogs
-                        .iter()
-                        .any(|cat| cat.find_schema(&path_str, file_name).is_some())
-                {
-                    match JsoncParser.parse(&content, &path_str) {
-                        Ok(val) => (parsers::parser_for(FileFormat::Jsonc), val),
-                        Err(jsonc_err) => return FileResult::Error(jsonc_err.into()),
-                    }
-                } else {
-                    return FileResult::Error(parse_err.into());
-                }
-            }
+            Err(parse_err) => return FileResult::Error(parse_err.into()),
         }
     } else {
         match try_parse_all(&content, &path_str) {


### PR DESCRIPTION
## Summary
- `.json` files are now parsed using the JSONC parser, which supports comments and trailing commas
- JSONC is a strict superset of JSON, so all valid JSON files parse identically
- Removes the conditional JSONC fallback that only triggered when strict JSON parsing failed and a catalog entry matched — now all `.json` files get JSONC support unconditionally

## Test plan
- [x] All 100 existing `lintel-validate` tests pass
- [x] Clippy clean
- [ ] Verify `lintel check` on a `.json` file containing comments