### PR TITLE
Fix static musl builds and add smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Build
         run: nix build ${{ matrix.nix-package }}
 
+      - name: Smoke test
+        run: ./result/bin/${{ matrix.binary }} version
+
       - name: Package
         run: tar czf ${{ matrix.binary }}-${{ matrix.target }}.tar.gz -C result/bin ${{ matrix.binary }}
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,19 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         craneLib = crane.mkLib pkgs;
-        craneLibStatic = if pkgs.stdenv.isLinux then crane.mkLib pkgs.pkgsStatic else null;
+        craneLibStatic =
+          if pkgs.stdenv.isLinux then
+            let
+              muslPkgs =
+                {
+                  "x86_64-linux" = pkgs.pkgsCross.musl64;
+                  "aarch64-linux" = pkgs.pkgsCross.aarch64-multiplatform-musl;
+                }
+                .${system};
+            in
+            crane.mkLib muslPkgs
+          else
+            null;
 
         src =
           let


### PR DESCRIPTION
## Summary

- **Fix musl static builds**: Replace `pkgs.pkgsStatic` with `pkgs.pkgsCross.musl64` / `pkgs.pkgsCross.aarch64-multiplatform-musl` in `flake.nix`. `pkgsStatic` forced the entire toolchain to use static linking, causing host-side build scripts (`proc-macro2`, `libc`) to fail with `attempted static link of dynamic object` errors against glibc `.so` files. `pkgsCross` properly separates host (dynamic glibc) and target (static musl) toolchains.
- **Add `version` subcommand to lintel-github-action**: Allows running `lintel-github-action version` without requiring `GITHUB_TOKEN` or other GitHub environment variables, enabling use in CI smoke tests.
- **Add post-build smoke test**: Every build matrix entry now runs `./result/bin/<binary> version` after the Nix build to verify the binary actually executes.

## Test plan

- [ ] CI build passes for `x86_64-unknown-linux-musl` (previously failing)
- [ ] CI build passes for `aarch64-unknown-linux-musl`
- [ ] Smoke test step runs successfully for all matrix entries
- [ ] Existing `lintel-github-action` invocation (without `run` subcommand) still works