### PR TITLE
Add no-std category to no_std-compatible crates

### DIFF
--- a/crates/dprint-config/Cargo.toml
+++ b/crates/dprint-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dprint-config"
 version = "0.0.1"
 authors.workspace = true
-categories = ["development-tools"]
+categories = ["development-tools", "no-std"]
 edition.workspace = true
 homepage.workspace = true
 keywords = ["dprint", "formatter", "config", "json-schema"]

--- a/crates/schema-catalog/Cargo.toml
+++ b/crates/schema-catalog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "schema-catalog"
 version = "0.0.5"
 authors.workspace = true
-categories = ["data-structures"]
+categories = ["data-structures", "no-std"]
 edition.workspace = true
 homepage.workspace = true
 keywords = ["json-schema", "catalog", "schemastore"]


### PR DESCRIPTION
## Summary
- Add the `no-std` crates.io category to `dprint-config` and `schema-catalog`, which both use `#![no_std]`

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Confirm categories render correctly on crates.io after publish