### PR TITLE
Inject x-lintel metadata into local schemas

### DIFF
--- a/crates/lintel-catalog-builder/src/config.rs
+++ b/crates/lintel-catalog-builder/src/config.rs
@@ -62,6 +62,18 @@ pub struct CatalogMeta {
     #[schemars(example = &"Lintel Schema Catalog")]
     #[serde(default)]
     pub title: Option<String>,
+
+    /// Base URL for local schema source files.
+    ///
+    /// When set, local schemas (those without a `url`) get their `x-lintel`
+    /// `source` field constructed as `{source-base-url}/schemas/{group}/{key}.json`.
+    /// This is typically a raw GitHub URL pointing to the catalog repository.
+    ///
+    /// When omitted, local schemas use a relative path like
+    /// `schemas/{group}/{key}.json`.
+    #[schemars(example = &"https://raw.githubusercontent.com/lintel-rs/catalog/master")]
+    #[serde(default)]
+    pub source_base_url: Option<String>,
 }
 
 /// Options for GitHub Pages hosting.
@@ -448,6 +460,28 @@ url = "https://www.schemastore.org/api/json/catalog.json"
         let config = load_config(toml).expect("parse");
         let ss = &config.sources["schemastore"];
         assert!(ss.exclude_matches.is_empty());
+    }
+
+    #[test]
+    fn parse_source_base_url() {
+        let toml = r#"
+[catalog]
+source-base-url = "https://raw.githubusercontent.com/lintel-rs/catalog/master"
+"#;
+        let config = load_config(toml).expect("parse");
+        assert_eq!(
+            config.catalog.source_base_url.as_deref(),
+            Some("https://raw.githubusercontent.com/lintel-rs/catalog/master")
+        );
+    }
+
+    #[test]
+    fn source_base_url_defaults_to_none() {
+        let toml = r"
+[catalog]
+";
+        let config = load_config(toml).expect("parse");
+        assert!(config.catalog.source_base_url.is_none());
     }
 
     #[test]

--- a/crates/lintel-catalog-builder/src/generate/mod.rs
+++ b/crates/lintel-catalog-builder/src/generate/mod.rs
@@ -146,6 +146,7 @@ async fn generate_for_target(
             group_key,
             trimmed_base,
             processed: ctx.processed,
+            source_base_url: ctx.config.catalog.source_base_url.as_deref(),
         };
         for (key, schema_def) in &group_config.schemas {
             let entry =

--- a/crates/lintel-catalog-builder/src/generate/sources.rs
+++ b/crates/lintel-catalog-builder/src/generate/sources.rs
@@ -255,6 +255,7 @@ async fn process_one_source_schema(
                 already_downloaded: &mut already_downloaded,
                 source_url: Some(source_url.clone()),
                 processed: ctx.processed,
+                lintel_source: None,
             };
 
             debug!(schema = %info.name, "processing schema refs");


### PR DESCRIPTION
## Summary

- Local group schemas (those without a `url` in config) were missing `x-lintel` properties because injection required an HTTP cache content hash that doesn't exist for local files
- Added `source-base-url` config field to `[catalog]` section for constructing GitHub raw URLs as the `x-lintel` source identifier
- Refactored `inject_lintel_extra` to accept pre-computed hashes directly, with a `_from_cache` wrapper for remote schemas
- Added `lintel_source` field to `RefRewriteContext` so local schemas compute SHA-256 from file content and get the same `x-lintel` injection as remote ones

## Test plan

- [x] All 64 existing tests pass
- [x] Clippy clean
- [x] Added config parsing tests for `source-base-url`
- [ ] Run catalog builder against lintel-rs/catalog repo to verify local schemas (e.g. claude-code/agent, lintel/catalog) now have `x-lintel` in output