### PR TITLE
Add fileMatch and parsers to x-lintel metadata

### DIFF
--- a/crates/lintel-catalog-builder/src/download.rs
+++ b/crates/lintel-catalog-builder/src/download.rs
@@ -1,3 +1,4 @@
+use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -5,6 +6,7 @@ use std::sync::Mutex;
 
 use anyhow::Result;
 use lintel_schema_cache::{CacheStatus, SchemaCache};
+use schema_catalog::FileFormat;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -71,15 +73,21 @@ const MAX_SCHEMA_SIZE: u64 = 10 * 1024 * 1024;
 
 /// Metadata injected into downloaded schemas as `x-lintel`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LintelExtra {
     /// Original URL the schema was fetched from.
     pub source: String,
     /// SHA-256 hex digest of the raw schema content before any transformations.
-    #[serde(rename = "sourceSha256")]
     pub source_sha256: String,
     /// `true` when the schema fails validation after transformation.
     #[serde(default, skip_serializing_if = "is_false")]
     pub invalid: bool,
+    /// Glob patterns for files this schema should be associated with.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_match: Vec<String>,
+    /// Parsers that can handle files matched by this schema.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parsers: Vec<FileFormat>,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)] // serde requires fn(&bool) -> bool
@@ -117,18 +125,14 @@ fn is_schema_invalid(value: &serde_json::Value) -> bool {
 
 /// Inject `x-lintel` metadata into a schema's root object.
 ///
-/// Takes the source identifier and pre-computed SHA-256 hash directly.
 /// Validates the schema and sets `invalid: true` if it fails compilation.
-pub fn inject_lintel_extra(value: &mut serde_json::Value, source: &str, source_sha256: String) {
+/// The `extra` struct is completed with the `invalid` flag before insertion.
+pub fn inject_lintel_extra(value: &mut serde_json::Value, mut extra: LintelExtra) {
     let invalid = is_schema_invalid(value);
     if invalid {
-        warn!(source = %source, "schema is invalid after transformation");
+        warn!(source = %extra.source, "schema is invalid after transformation");
     }
-    let extra = LintelExtra {
-        source: source.to_string(),
-        source_sha256,
-        invalid,
-    };
+    extra.invalid = invalid;
     if let Some(obj) = value.as_object_mut() {
         obj.insert(
             "x-lintel".to_string(),
@@ -140,16 +144,18 @@ pub fn inject_lintel_extra(value: &mut serde_json::Value, source: &str, source_s
 /// Inject `x-lintel` metadata using the HTTP cache to look up the content hash.
 ///
 /// If the hash is not available (e.g. the schema was never fetched via HTTP),
-/// no metadata is injected.
+/// no metadata is injected. The provided `extra` is completed with the
+/// source hash before injection.
 pub fn inject_lintel_extra_from_cache(
     value: &mut serde_json::Value,
-    source_url: &str,
     cache: &SchemaCache,
+    mut extra: LintelExtra,
 ) {
-    let Some(hash) = cache.content_hash(source_url) else {
+    let Some(hash) = cache.content_hash(&extra.source) else {
         return;
     };
-    inject_lintel_extra(value, source_url, hash);
+    extra.source_sha256 = hash;
+    inject_lintel_extra(value, extra);
 }
 
 /// Fetch a schema via the cache. Returns the parsed `Value` and cache status.
@@ -157,6 +163,32 @@ pub fn inject_lintel_extra_from_cache(
 pub async fn fetch_one(cache: &SchemaCache, url: &str) -> Result<(serde_json::Value, CacheStatus)> {
     let (value, status) = cache.fetch(url).await.map_err(|e| anyhow::anyhow!("{e}"))?;
     Ok((value, status))
+}
+
+/// Derive file formats from `fileMatch` glob patterns by inspecting extensions.
+///
+/// Returns a sorted, deduplicated list of formats.
+pub fn parsers_from_file_match(patterns: &[String]) -> Vec<FileFormat> {
+    let mut parsers: BTreeSet<FileFormat> = BTreeSet::new();
+    for pattern in patterns {
+        // Strip leading path components (e.g. "**/*.yml" → "*.yml")
+        let base = pattern.rsplit('/').next().unwrap_or(pattern);
+        if let Some(dot_pos) = base.rfind('.') {
+            let format = match &base[dot_pos..] {
+                ".json" => Some(FileFormat::Json),
+                ".jsonc" => Some(FileFormat::Jsonc),
+                ".json5" => Some(FileFormat::Json5),
+                ".yaml" | ".yml" => Some(FileFormat::Yaml),
+                ".toml" => Some(FileFormat::Toml),
+                ".md" | ".mdx" => Some(FileFormat::Markdown),
+                _ => None,
+            };
+            if let Some(f) = format {
+                parsers.insert(f);
+            }
+        }
+    }
+    parsers.into_iter().collect()
 }
 
 /// Preferred key order for the root object of a JSON Schema.

--- a/crates/lintel-catalog-builder/src/generate/groups.rs
+++ b/crates/lintel-catalog-builder/src/generate/groups.rs
@@ -124,6 +124,7 @@ pub(super) async fn process_group_schema(
         lintel_source: lintel_source
             .as_ref()
             .map(|(id, hash, _)| (id.clone(), hash.clone())),
+        file_match: schema_def.file_match.clone(),
     };
 
     // Process schema result

--- a/crates/lintel-catalog-builder/src/generate/sources.rs
+++ b/crates/lintel-catalog-builder/src/generate/sources.rs
@@ -256,6 +256,7 @@ async fn process_one_source_schema(
                 source_url: Some(source_url.clone()),
                 processed: ctx.processed,
                 lintel_source: None,
+                file_match: info.file_match.clone(),
             };
 
             debug!(schema = %info.name, "processing schema refs");

--- a/crates/lintel-validate/src/parsers/mod.rs
+++ b/crates/lintel-validate/src/parsers/mod.rs
@@ -18,15 +18,7 @@ pub use self::markdown::MarkdownParser;
 pub use self::toml_parser::TomlParser;
 pub use self::yaml::YamlParser;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FileFormat {
-    Json,
-    Json5,
-    Jsonc,
-    Toml,
-    Yaml,
-    Markdown,
-}
+pub use schema_catalog::FileFormat;
 
 /// Parse file content into a `serde_json::Value`.
 ///

--- a/crates/schema-catalog/src/lib.rs
+++ b/crates/schema-catalog/src/lib.rs
@@ -96,6 +96,7 @@ pub struct CatalogGroup {
 ///
 /// Each entry maps a schema to its URL and the file patterns it applies to.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 #[schemars(title = "Schema Entry")]
 pub struct SchemaEntry {
     /// The display name of the schema.
@@ -109,13 +110,13 @@ pub struct SchemaEntry {
     pub url: String,
     /// An optional URL pointing to the upstream or canonical source of
     /// the schema (e.g. a GitHub raw URL).
-    #[serde(default, rename = "sourceUrl", skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_url: Option<String>,
     /// Glob patterns for files this schema should be applied to.
     ///
     /// Editors and tools use these patterns to automatically associate
     /// matching files with this schema.
-    #[serde(default, rename = "fileMatch", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schemars(title = "File Match")]
     #[schemars(example = example_file_match())]
     pub file_match: Vec<String>,
@@ -139,6 +140,20 @@ fn example_schema_url() -> String {
 
 fn example_file_match() -> Vec<String> {
     vec!["*.config.json".to_owned(), "**/.config.json".to_owned()]
+}
+
+/// Supported file formats for parsing and validation.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum FileFormat {
+    Json,
+    Json5,
+    Jsonc,
+    Toml,
+    Yaml,
+    Markdown,
 }
 
 /// Generate the JSON Schema for the [`Catalog`] type.


### PR DESCRIPTION
## Summary
- Add `fileMatch` and `parsers` fields to the `x-lintel` metadata injected into downloaded schemas
- Move `FileFormat` enum from `lintel-validate` to `schema-catalog` so it can be shared across crates
- Use `#[serde(rename_all = "camelCase")]` on `LintelExtra` and `SchemaEntry` instead of per-field renames

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all tests green)
- [ ] Verify generated schemas contain `fileMatch` and `parsers` in `x-lintel` block