### PR TITLE
Add static/ directory support to catalog builder

### DIFF
--- a/crates/lintel-catalog-builder/src/generate/mod.rs
+++ b/crates/lintel-catalog-builder/src/generate/mod.rs
@@ -231,6 +231,7 @@ async fn generate_for_target(
     let output_ctx = OutputContext {
         output_dir,
         config_path: ctx.config_path,
+        config_dir: ctx.config_dir,
         catalog: &catalog,
         groups_meta: &groups_meta_vec,
         base_url,

--- a/crates/lintel-catalog-builder/src/html/mod.rs
+++ b/crates/lintel-catalog-builder/src/html/mod.rs
@@ -353,6 +353,7 @@ mod tests {
         let ctx = OutputContext {
             output_dir: dir.path(),
             config_path: Path::new("lintel-catalog.toml"),
+            config_dir: dir.path(),
             catalog: &catalog,
             groups_meta: &groups_meta,
             base_url: "https://example.com/",


### PR DESCRIPTION
## Summary

- Add support for copying a `static/` directory (relative to the config file) into the output root during site generation
- Static files are copied last during finalization, so they can override generated content if desired
- Enables including arbitrary files like `llms.txt`, `robots.txt`, or favicons in the generated catalog site

## Test plan

- [x] `cargo build -p lintel-catalog-builder` compiles
- [x] `cargo test -p lintel-catalog-builder` passes (57 tests including 2 new: recursive copy + noop when missing)
- [ ] Run `lintel-catalog-builder generate` against catalog with a `static/llms.txt` and verify it appears in output