### PR TITLE
Add shell file/directory completion to CLI arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/lintel-rs/lintel"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-bpaf = { version = "0.9.23", features = ["derive"] }
+bpaf = { version = "0.9.23", features = ["autocomplete", "derive"] }
 criterion = "0.8.2"
 glob = "0.3.3"
 glob-match = "0.2.1"

--- a/crates/lintel-annotate/src/lib.rs
+++ b/crates/lintel-annotate/src/lib.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 
 use lintel_cli_common::CliCacheOptions;
 use lintel_schema_cache::SchemaCache;
@@ -29,7 +29,7 @@ pub struct AnnotateArgs {
     #[bpaf(long("update"), switch)]
     pub update: bool,
 
-    #[bpaf(positional("PATH"))]
+    #[bpaf(positional("PATH"), complete_shell(ShellComp::File { mask: None }))]
     pub globs: Vec<String>,
 }
 

--- a/crates/lintel-cli-common/src/lib.rs
+++ b/crates/lintel-cli-common/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::time::Duration;
 
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 
 /// Global options applied to all commands
 #[derive(Debug, Clone, Bpaf)]
@@ -100,7 +100,7 @@ fn parse_duration(s: String) -> Result<Duration, String> {
 #[bpaf(generate(cli_cache_options))]
 #[allow(clippy::struct_excessive_bools)]
 pub struct CliCacheOptions {
-    #[bpaf(long("cache-dir"), argument("DIR"))]
+    #[bpaf(long("cache-dir"), argument("DIR"), complete_shell(ShellComp::Dir { mask: None }))]
     pub cache_dir: Option<String>,
 
     /// Schema cache TTL (e.g. "12h", "30m", "1d"); default 12h

--- a/crates/lintel-explain/src/lib.rs
+++ b/crates/lintel-explain/src/lib.rs
@@ -6,7 +6,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 
 use lintel_cli_common::{CLIGlobalOptions, CliCacheOptions};
 
@@ -20,19 +20,19 @@ pub struct ExplainArgs {
     /// Schema URL or local file path to explain.
     /// Can be combined with `--file` or `--path` to override schema resolution
     /// while still validating the data file.
-    #[bpaf(long("schema"), argument("URL|FILE"))]
+    #[bpaf(long("schema"), argument("URL|FILE"), complete_shell(ShellComp::File { mask: None }))]
     pub schema: Option<String>,
 
     /// Data file (local path or URL) to resolve the schema from and validate.
     /// The file must exist (or be fetchable). For URLs, the filename is used
     /// for catalog matching.
-    #[bpaf(long("file"), argument("FILE|URL"))]
+    #[bpaf(long("file"), argument("FILE|URL"), complete_shell(ShellComp::File { mask: None }))]
     pub file: Option<String>,
 
     /// File path or URL to resolve the schema from using catalogs.
     /// Local files need not exist; if the file exists (or is a URL), it is
     /// also validated.
-    #[bpaf(long("path"), argument("FILE|URL"))]
+    #[bpaf(long("path"), argument("FILE|URL"), complete_shell(ShellComp::File { mask: None }))]
     pub resolve_path: Option<String>,
 
     #[bpaf(external(lintel_cli_common::cli_cache_options))]
@@ -53,7 +53,7 @@ pub struct ExplainArgs {
     /// Examples:
     /// - `lintel explain package.json`       — explains the schema for `package.json`
     /// - `lintel explain --file f.yaml name`  — explains the `name` property
-    #[bpaf(positional("FILE|POINTER"))]
+    #[bpaf(positional("FILE|POINTER"), complete_shell(ShellComp::File { mask: None }))]
     pub positional: Option<String>,
 
     /// JSON Pointer (`/properties/name`) or `JSONPath` (`$.name`) to a sub-schema.

--- a/crates/lintel-format/src/lib.rs
+++ b/crates/lintel-format/src/lib.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 use miette::Diagnostic;
 use thiserror::Error;
 
@@ -525,7 +525,7 @@ pub struct FormatArgs {
     #[bpaf(long("exclude"), argument("PATTERN"))]
     pub exclude: Vec<String>,
 
-    #[bpaf(positional("PATH"))]
+    #[bpaf(positional("PATH"), complete_shell(ShellComp::File { mask: None }))]
     pub globs: Vec<String>,
 }
 

--- a/crates/lintel-identify/src/lib.rs
+++ b/crates/lintel-identify/src/lib.rs
@@ -5,7 +5,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 use lintel_cli_common::{CLIGlobalOptions, CliCacheOptions};
 
 use lintel_schema_cache::SchemaCache;
@@ -36,7 +36,7 @@ pub struct IdentifyArgs {
     pub no_pager: bool,
 
     /// File to identify
-    #[bpaf(positional("FILE"))]
+    #[bpaf(positional("FILE"), complete_shell(ShellComp::File { mask: None }))]
     pub file: String,
 }
 

--- a/crates/lintel-validate/src/lib.rs
+++ b/crates/lintel-validate/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use std::time::Instant;
 
 use anyhow::Result;
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 
 use lintel_cli_common::CliCacheOptions;
 
@@ -36,7 +36,7 @@ pub struct ValidateArgs {
     #[bpaf(external(lintel_cli_common::cli_cache_options))]
     pub cache: CliCacheOptions,
 
-    #[bpaf(positional("PATH"))]
+    #[bpaf(positional("PATH"), complete_shell(ShellComp::File { mask: None }))]
     pub globs: Vec<String>,
 }
 

--- a/crates/lintel/Cargo.toml
+++ b/crates/lintel/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 ansi-term-styles = "0.1.0"
 anyhow.workspace = true
-bpaf = { workspace = true, features = ["autocomplete", "bright-color", "docgen"] }
+bpaf = { workspace = true, features = ["bright-color", "docgen"] }
 glob-match.workspace = true
 humantime = "2.3.0"
 lintel-annotate = { version = "0.0.12", path = "../lintel-annotate" }

--- a/crates/lintel/src/commands/cache.rs
+++ b/crates/lintel/src/commands/cache.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 use lintel_cli_common::CLIGlobalOptions;
 
 use lintel_schema_cache::{CacheStatus, SchemaCache};
@@ -22,7 +22,7 @@ pub enum CacheCommand {
 
 #[derive(Debug, Clone, Bpaf)]
 pub struct InspectSchemaArgs {
-    #[bpaf(long("cache-dir"), argument("DIR"))]
+    #[bpaf(long("cache-dir"), argument("DIR"), complete_shell(ShellComp::Dir { mask: None }))]
     pub cache_dir: Option<String>,
 
     /// Schema URL to inspect
@@ -32,7 +32,7 @@ pub struct InspectSchemaArgs {
 
 #[derive(Debug, Clone, Bpaf)]
 pub struct TraceArgs {
-    #[bpaf(long("cache-dir"), argument("DIR"))]
+    #[bpaf(long("cache-dir"), argument("DIR"), complete_shell(ShellComp::Dir { mask: None }))]
     pub cache_dir: Option<String>,
 
     /// Schema cache TTL (e.g. "12h", "30m", "1d"); default 12h
@@ -43,7 +43,7 @@ pub struct TraceArgs {
     pub no_catalog: bool,
 
     /// File to trace
-    #[bpaf(positional("FILE"))]
+    #[bpaf(positional("FILE"), complete_shell(ShellComp::File { mask: None }))]
     pub file: String,
 }
 

--- a/crates/lintel/src/main.rs
+++ b/crates/lintel/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::process::ExitCode;
 
-use bpaf::Bpaf;
+use bpaf::{Bpaf, ShellComp};
 use lintel_cli_common::CLIGlobalOptions;
 use tracing_subscriber::prelude::*;
 
@@ -45,7 +45,7 @@ pub struct ConvertArgs {
     pub to: OutputFormat,
 
     /// Input file to convert
-    #[bpaf(positional("FILE"))]
+    #[bpaf(positional("FILE"), complete_shell(ShellComp::File { mask: None }))]
     pub file: String,
 }
 


### PR DESCRIPTION
## Summary
- Add `complete_shell(ShellComp::File { mask: None })` to all positional and named arguments that accept file paths across all subcommands (check, ci, validate, identify, explain, convert, format, annotate, cache trace)
- Add `complete_shell(ShellComp::Dir { mask: None })` to all `--cache-dir` arguments
- Move `autocomplete` feature to workspace-level bpaf dependency so all sub-crates can use `ShellComp`

bpaf's generated shell completion scripts take over the shell's default completion behavior. Without explicit `complete_shell` annotations, the shell doesn't know to offer filesystem path suggestions for file/directory arguments.

## Test plan
- [x] `cargo check` passes
- [x] All 250 tests pass
- [x] Verified `_files` is emitted in zsh completion output for file arguments
- [x] Verified `_files -/` is emitted for `--cache-dir` (directory-only completion)