### PR TITLE
Add catalogDescription property to x-lintel metadata

### DIFF
--- a/crates/lintel-catalog-builder/src/download.rs
+++ b/crates/lintel-catalog-builder/src/download.rs
@@ -90,6 +90,9 @@ pub struct LintelExtra {
     /// Parsers that can handle files matched by this schema.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parsers: Vec<FileFormat>,
+    /// Brief description used to populate the catalog entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_description: Option<String>,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)] // serde requires fn(&bool) -> bool
@@ -135,6 +138,12 @@ pub fn inject_lintel_extra(value: &mut serde_json::Value, mut extra: LintelExtra
         warn!(source = %extra.source, "schema is invalid after transformation");
     }
     extra.invalid = invalid;
+    // Preserve catalogDescription from existing x-lintel if not already set.
+    if extra.catalog_description.is_none()
+        && let Some(existing) = parse_lintel_extra(value)
+    {
+        extra.catalog_description = existing.catalog_description;
+    }
     if let Some(obj) = value.as_object_mut() {
         obj.insert(
             "x-lintel".to_string(),

--- a/crates/lintel-catalog-builder/src/generate/groups.rs
+++ b/crates/lintel-catalog-builder/src/generate/groups.rs
@@ -181,7 +181,7 @@ pub(super) async fn process_group_schema(
     let version_urls = process_fetched_versions(&mut ref_ctx, &entry_dir, version_results).await?;
 
     // Auto-populate name and description from the JSON Schema
-    let (schema_title, schema_desc) = extract_schema_meta(&schema_text);
+    let (schema_title, schema_desc, catalog_desc) = extract_schema_meta(&schema_text);
     let name = schema_def
         .name
         .clone()
@@ -190,8 +190,9 @@ pub(super) async fn process_group_schema(
     let description = schema_def
         .description
         .clone()
-        .or(schema_title)
+        .or(catalog_desc)
         .or_else(|| schema_desc.as_deref().map(first_line))
+        .or(schema_title)
         .unwrap_or_default();
 
     Ok(SchemaEntry {

--- a/crates/lintel-catalog-builder/src/generate/util.rs
+++ b/crates/lintel-catalog-builder/src/generate/util.rs
@@ -134,13 +134,14 @@ fn version_gt(a: &str, b: &str) -> bool {
     }
 }
 
-/// Extract the `title` and `description` from a JSON Schema string.
+/// Extract the `title`, `description`, and `x-lintel.catalogDescription` from a
+/// JSON Schema string.
 ///
-/// Returns `(title, description)` — either or both may be `None` if the schema
-/// doesn't contain the corresponding top-level property or isn't valid JSON.
-pub(super) fn extract_schema_meta(text: &str) -> (Option<String>, Option<String>) {
+/// Returns `(title, description, catalog_description)` — any may be `None` if
+/// the schema doesn't contain the corresponding property or isn't valid JSON.
+pub(super) fn extract_schema_meta(text: &str) -> (Option<String>, Option<String>, Option<String>) {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
-        return (None, None);
+        return (None, None, None);
     };
     let title = value
         .get("title")
@@ -150,7 +151,9 @@ pub(super) fn extract_schema_meta(text: &str) -> (Option<String>, Option<String>
         .get("description")
         .and_then(|v| v.as_str())
         .map(String::from);
-    (title, description)
+    let catalog_description =
+        crate::download::parse_lintel_extra(&value).and_then(|extra| extra.catalog_description);
+    (title, description, catalog_description)
 }
 
 /// Extract `fileMatch` and `parsers` from a JSON Schema value.

--- a/crates/lintel-catalog-builder/src/refs.rs
+++ b/crates/lintel-catalog-builder/src/refs.rs
@@ -315,6 +315,7 @@ fn inject_lintel(value: &mut serde_json::Value, ctx: &RefRewriteContext<'_>) {
                 invalid: false,
                 file_match: ctx.file_match.clone(),
                 parsers,
+                catalog_description: None,
             },
         );
     } else if let Some(ref source_url) = ctx.source_url {
@@ -327,6 +328,7 @@ fn inject_lintel(value: &mut serde_json::Value, ctx: &RefRewriteContext<'_>) {
                 invalid: false,
                 file_match: ctx.file_match.clone(),
                 parsers,
+                catalog_description: None,
             },
         );
     }
@@ -568,6 +570,7 @@ async fn write_dep_schemas(
                     invalid: false,
                     file_match: Vec::new(),
                     parsers: Vec::new(),
+                    catalog_description: None,
                 },
             );
         }


### PR DESCRIPTION
## Summary
- Adds an optional `catalogDescription` field to `LintelExtra` (`x-lintel`) for providing brief schema descriptions in catalog.json entries
- Updates the catalog description fallback chain: config override > `catalogDescription` > first line of schema `description` > schema `title`
- Preserves existing `catalogDescription` values during x-lintel injection so manual edits survive rebuilds

## Test plan
- [x] `cargo check -p lintel-catalog-builder` passes
- [x] `cargo test -p lintel-catalog-builder` — all 57 tests pass
- [x] Clippy pedantic passes