### PR TITLE
Support relative $ref resolution in local schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,6 +1809,7 @@ name = "lintel-validate"
 version = "0.0.7"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bpaf",
  "glob",
  "glob-match",
@@ -1822,6 +1823,7 @@ dependencies = [
  "lintel-schema-cache",
  "lintel-validation-cache",
  "miette",
+ "percent-encoding",
  "schema-catalog",
  "serde_json",
  "serde_yaml",

--- a/crates/lintel-validate/Cargo.toml
+++ b/crates/lintel-validate/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+async-trait = "0.1.89"
+percent-encoding = "2.3.2"
 bpaf.workspace = true
 glob.workspace = true
 glob-match.workspace = true


### PR DESCRIPTION
## Summary

- Add `LocalRetriever` composite that dispatches `file://` URIs to local disk reads (with percent-decoding) and delegates HTTP/HTTPS URIs to `SchemaCache`
- Set a `file://` base URI for local schemas via `canonicalize` so the `jsonschema` crate can resolve relative `$ref` values like `"./defs.json"`
- Add test verifying relative `$ref` resolution works for both valid and invalid data files

## Test plan

- [x] `cargo test -p lintel-validate` — all 116 tests pass
- [x] `cargo clippy --workspace` — no warnings
- [ ] Manual test with a real schema that uses relative `$ref`