### PR TITLE
Improve SEO for catalog site and add /schemas/ index page

### DIFF
--- a/crates/lintel-catalog-builder/src/config.rs
+++ b/crates/lintel-catalog-builder/src/config.rs
@@ -130,6 +130,14 @@ pub struct SiteConfig {
     #[schemars(example = &"G-XXXXXXXXXX")]
     #[serde(default)]
     pub ga_tracking_id: Option<String>,
+    /// Full URL to an Open Graph image for social sharing previews.
+    ///
+    /// When set, `<meta property="og:image">` and Twitter Card tags are added
+    /// to every page. The image should be hosted at a publicly accessible URL
+    /// (e.g. in the `static/` directory of your catalog repo).
+    #[schemars(example = &"https://catalog.example.com/og-image.png")]
+    #[serde(default)]
+    pub og_image: Option<String>,
     /// GitHub Pages hosting options.
     #[serde(default)]
     pub github: Option<GitHubPagesConfig>,

--- a/crates/lintel-catalog-builder/src/generate/mod.rs
+++ b/crates/lintel-catalog-builder/src/generate/mod.rs
@@ -228,6 +228,7 @@ async fn generate_for_target(
         .site
         .as_ref()
         .and_then(|s| s.ga_tracking_id.as_deref());
+    let og_image = target.site.as_ref().and_then(|s| s.og_image.as_deref());
     let output_ctx = OutputContext {
         output_dir,
         config_path: ctx.config_path,
@@ -239,6 +240,7 @@ async fn generate_for_target(
         processed: ctx.processed,
         site_description,
         ga_tracking_id,
+        og_image,
     };
 
     targets::finalize(target, &output_ctx).await?;

--- a/crates/lintel-catalog-builder/src/html/engine.rs
+++ b/crates/lintel-catalog-builder/src/html/engine.rs
@@ -107,6 +107,10 @@ fn register_templates(env: &mut Environment<'static>) -> Result<()> {
         ("schema.html", include_str!("templates/schema.html")),
         ("version.html", include_str!("templates/version.html")),
         ("shared.html", include_str!("templates/shared.html")),
+        (
+            "schemas_index.html",
+            include_str!("templates/schemas_index.html"),
+        ),
         ("sitemap.xml", include_str!("templates/sitemap.xml")),
         (
             "components/schema_card.html",

--- a/crates/lintel-catalog-builder/src/html/mod.rs
+++ b/crates/lintel-catalog-builder/src/html/mod.rs
@@ -13,7 +13,8 @@ use crate::download::ProcessedSchemas;
 use crate::targets::OutputContext;
 use context::{
     SharedSchemaPage, SiteInfo, build_group_page, build_home_context, build_schema_page,
-    build_site_info, build_version_page, schema_group_map, schema_page_url, version_page_url,
+    build_schemas_index, build_site_info, build_version_page, schema_group_map, schema_page_url,
+    version_page_url,
 };
 
 /// Generate all HTML pages, assets, search index, and sitemap.
@@ -23,10 +24,12 @@ pub async fn generate_site(ctx: &OutputContext<'_>) -> Result<()> {
     let mut sitemap_urls: Vec<String> = Vec::new();
 
     render_home_page(&env, &site, ctx)?;
+    render_schemas_index(&env, &site, ctx, &mut sitemap_urls)?;
     render_group_pages(&env, &site, ctx, &mut sitemap_urls)?;
     render_schema_pages(&env, &site, ctx, &mut sitemap_urls)?;
     render_shared_pages(&env, &site, ctx, &mut sitemap_urls)?;
     render_sitemap(&env, &site, ctx.output_dir, &sitemap_urls)?;
+    write_robots_txt(ctx.output_dir, &site.base_url)?;
 
     assets::write_assets(ctx.output_dir).await?;
     search::write_search_index(ctx.output_dir, ctx.catalog, ctx.base_url, ctx.groups_meta).await?;
@@ -47,6 +50,26 @@ fn render_home_page(
     std::fs::write(&path, html)
         .with_context(|| alloc::format!("failed to write {}", path.display()))?;
     debug!(path = %path.display(), "wrote index.html");
+    Ok(())
+}
+
+/// Render and write the `/schemas/` index page.
+fn render_schemas_index(
+    env: &minijinja::Environment<'_>,
+    site: &SiteInfo,
+    ctx: &OutputContext<'_>,
+    sitemap_urls: &mut Vec<String>,
+) -> Result<()> {
+    let page = build_schemas_index(ctx, site);
+    let html = engine::render(env, "schemas_index.html", &page)?;
+    let dir = ctx.output_dir.join("schemas");
+    std::fs::create_dir_all(&dir)
+        .with_context(|| alloc::format!("failed to create {}", dir.display()))?;
+    let path = dir.join("index.html");
+    std::fs::write(&path, html)
+        .with_context(|| alloc::format!("failed to write {}", path.display()))?;
+    debug!(path = %path.display(), "wrote schemas index");
+    sitemap_urls.push(String::from("schemas/"));
     Ok(())
 }
 
@@ -264,15 +287,81 @@ fn render_sitemap(
     output_dir: &Path,
     urls: &[String],
 ) -> Result<()> {
+    let lastmod = today_iso8601();
     let sitemap_ctx = context::SitemapContext {
         base_url: site.base_url.clone(),
         urls: urls.to_vec(),
+        lastmod,
     };
     let xml = engine::render(env, "sitemap.xml", &sitemap_ctx)?;
     let path = output_dir.join("sitemap.xml");
     std::fs::write(&path, xml)
         .with_context(|| alloc::format!("failed to write {}", path.display()))?;
     debug!(path = %path.display(), "wrote sitemap.xml");
+    Ok(())
+}
+
+/// Return today's date as an ISO 8601 string (e.g. `2025-01-15`).
+fn today_iso8601() -> String {
+    // Compute date from UNIX epoch without pulling in a datetime crate.
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let days = secs / 86400;
+    // Simple Gregorian calendar calculation
+    let (year, month, day) = days_to_ymd(days);
+    alloc::format!("{year:04}-{month:02}-{day:02}")
+}
+
+/// Convert a count of days since 1970-01-01 to (year, month, day).
+fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+    let mut year = 1970;
+    loop {
+        let year_days = if is_leap(year) { 366 } else { 365 };
+        if days < year_days {
+            break;
+        }
+        days -= year_days;
+        year += 1;
+    }
+    let leap = is_leap(year);
+    let month_days: [u64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 1;
+    for &md in &month_days {
+        if days < md {
+            break;
+        }
+        days -= md;
+        month += 1;
+    }
+    (year, month, days + 1)
+}
+
+fn is_leap(year: u64) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+/// Write `robots.txt` to the output directory.
+fn write_robots_txt(output_dir: &Path, base_url: &str) -> Result<()> {
+    let content = alloc::format!("User-agent: *\nAllow: /\n\nSitemap: {base_url}sitemap.xml\n");
+    let path = output_dir.join("robots.txt");
+    std::fs::write(&path, content)
+        .with_context(|| alloc::format!("failed to write {}", path.display()))?;
+    debug!(path = %path.display(), "wrote robots.txt");
     Ok(())
 }
 
@@ -361,6 +450,7 @@ mod tests {
             processed: &processed,
             site_description: None,
             ga_tracking_id: None,
+            og_image: None,
         };
 
         generate_site(&ctx).await?;
@@ -389,11 +479,28 @@ mod tests {
             .join("schemas/github/workflow/versions/v2/index.html");
         assert!(version_path.exists());
 
+        // Schemas index page
+        let schemas_index_path = dir.path().join("schemas/index.html");
+        assert!(schemas_index_path.exists());
+        let schemas_index = std::fs::read_to_string(&schemas_index_path)?;
+        assert!(schemas_index.contains("All Schemas"));
+        assert!(schemas_index.contains("Workflow"));
+
         // Assets
         assert!(dir.path().join("style.css").exists());
         assert!(dir.path().join("app.js").exists());
         assert!(dir.path().join("search-index.json").exists());
         assert!(dir.path().join("sitemap.xml").exists());
+        assert!(dir.path().join("robots.txt").exists());
+
+        // Sitemap contains lastmod
+        let sitemap = std::fs::read_to_string(dir.path().join("sitemap.xml"))?;
+        assert!(sitemap.contains("<lastmod>"));
+        assert!(sitemap.contains("schemas/"));
+
+        // robots.txt points to sitemap
+        let robots = std::fs::read_to_string(dir.path().join("robots.txt"))?;
+        assert!(robots.contains("Sitemap: https://example.com/sitemap.xml"));
 
         Ok(())
     }

--- a/crates/lintel-catalog-builder/src/html/templates/group.html
+++ b/crates/lintel-catalog-builder/src/html/templates/group.html
@@ -1,21 +1,39 @@
-{% extends "layout.html" %} {% block title %}{{ name }} - {{ site.title }}{%
-endblock %} {% block description %}{{ seo_description }}{% endblock %} {% block
-canonical %}{{ site.base_url }}schemas/{{ key }}/{% endblock %} {% block
-og_title %}{{ name }} - {{ site.title }}{% endblock %} {% block og_description
-%}{{ seo_description }}{% endblock %} {% block og_url %}{{ site.base_url
-}}schemas/{{ key }}/{% endblock %} {% block jsonld %}
+{% extends "layout.html" %} {% block title %}{{ name }} JSON Schemas - {{
+site.title }}{% endblock %} {% block description %}{{ seo_description }}{%
+endblock %} {% block canonical %}{{ site.base_url }}schemas/{{ key }}/{%
+endblock %} {% block og_title %}{{ name }} JSON Schemas - {{ site.title }}{%
+endblock %} {% block og_description %}{{ seo_description }}{% endblock %} {%
+block og_url %}{{ site.base_url }}schemas/{{ key }}/{% endblock %} {% block
+jsonld %}
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "CollectionPage",
-    "name": "{{ name }}",
-    "description": "{{ description }}",
-    "url": "{{ site.base_url }}schemas/{{ key }}/",
-    "isPartOf": {
-      "@type": "WebSite",
-      "name": "{{ site.title }}",
-      "url": "{{ site.base_url }}"
-    }
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        "name": "{{ name }}",
+        "description": "{{ description }}",
+        "url": "{{ site.base_url }}schemas/{{ key }}/",
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "{{ site.title }}",
+          "url": "{{ site.base_url }}"
+        }
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {% for crumb in breadcrumbs %}
+          {
+            "@type": "ListItem",
+            "position": {{ loop.index }},
+            "name": "{{ crumb.label }}"{% if crumb.url %},
+            "item": "{{ site.base_url }}{{ crumb.url|replace(site.base_path, '') }}"{% endif %}
+          }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        ]
+      }
+    ]
   }
 </script>
 {% endblock %} {% block content %} {% include "components/breadcrumb.html" %}

--- a/crates/lintel-catalog-builder/src/html/templates/index.html
+++ b/crates/lintel-catalog-builder/src/html/templates/index.html
@@ -26,17 +26,21 @@
 {% endblock %} {% block content %}
 <div class="home-header">
   <h1>{{ site.title }}</h1>
-  <span class="home-stats"
-    >{{ site.schema_count|commafy }} {{ site.schema_count|pluralize("schema",
-    "schemas") }} &middot; {{ site.group_count|commafy }} {{
-    site.group_count|pluralize("group", "groups") }}</span
-  >
+  <p class="home-intro">
+    Browse {{ site.schema_count|commafy }} JSON Schemas for editor
+    auto-completion, validation, and documentation. Schemas are organized into
+    {{ site.group_count|commafy }} {{ site.group_count|pluralize("group",
+    "groups") }} covering popular tools and frameworks.
+  </p>
 </div>
 
 {% if groups %}
-<section class="card-grid">
-  {% for group in groups %} {% include "components/group_card.html" %} {% endfor
-  %}
+<section>
+  <h2 class="section-heading">Schema Groups</h2>
+  <div class="card-grid">
+    {% for group in groups %} {% include "components/group_card.html" %} {%
+    endfor %}
+  </div>
 </section>
 {% endif %} {% if unassigned %}
 <section class="unassigned-section">

--- a/crates/lintel-catalog-builder/src/html/templates/layout.html
+++ b/crates/lintel-catalog-builder/src/html/templates/layout.html
@@ -26,6 +26,20 @@
       property="og:url"
       content="{% block og_url %}{{ site.base_url }}{% endblock %}"
     />
+    {% if site.og_image %}
+    <meta property="og:image" content="{{ site.og_image }}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    {% else %}
+    <meta name="twitter:card" content="summary" />
+    {% endif %}
+    <meta
+      name="twitter:title"
+      content="{% block twitter_title %}{{ site.title }}{% endblock %}"
+    />
+    <meta
+      name="twitter:description"
+      content="{% block twitter_description %}{{ site.description }}{% endblock %}"
+    />
     <link rel="stylesheet" href="{{ site.base_path }}style.css" />
     {% if site.ga_tracking_id %}
     <!-- Google tag (gtag.js) -->

--- a/crates/lintel-catalog-builder/src/html/templates/schema.html
+++ b/crates/lintel-catalog-builder/src/html/templates/schema.html
@@ -1,23 +1,42 @@
-{% extends "layout.html" %} {% block title %}{{ name }} - {{ site.title }}{%
-endblock %} {% block description %}{{ seo_description }}{% endblock %} {% block
-canonical %}{{ site.base_url }}{{ page_url }}{% endblock %} {% block og_title
-%}{{ name }} - {{ site.title }}{% endblock %} {% block og_description %}{{
-seo_description }}{% endblock %} {% block og_url %}{{ site.base_url }}{{
-page_url }}{% endblock %} {% block jsonld %}
+{% extends "layout.html" %} {% block title %}{% if group_name %}{{ name }} ({{
+group_name }}) JSON Schema{% else %}{{ name }} JSON Schema{% endif %} - {{
+site.title }}{% endblock %} {% block description %}{{ seo_description }}{%
+endblock %} {% block canonical %}{{ site.base_url }}{{ page_url }}{% endblock %}
+{% block og_title %}{% if group_name %}{{ name }} ({{ group_name }}) JSON
+Schema{% else %}{{ name }} JSON Schema{% endif %} - {{ site.title }}{% endblock
+%} {% block og_description %}{{ seo_description }}{% endblock %} {% block og_url
+%}{{ site.base_url }}{{ page_url }}{% endblock %} {% block jsonld %}
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "SoftwareSourceCode",
-    "name": "{{ name }}",
-    "description": "{{ description }}",
-    "url": "{{ site.base_url }}{{ page_url }}",
-    "codeRepository": "{{ json_url }}",
-    "programmingLanguage": "JSON Schema",
-    "isPartOf": {
-      "@type": "WebSite",
-      "name": "{{ site.title }}",
-      "url": "{{ site.base_url }}"
-    }
+    "@graph": [
+      {
+        "@type": "SoftwareSourceCode",
+        "name": "{{ name }}",
+        "description": "{{ description }}",
+        "url": "{{ site.base_url }}{{ page_url }}",
+        "codeRepository": "{{ json_url }}",
+        "programmingLanguage": "JSON Schema",
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "{{ site.title }}",
+          "url": "{{ site.base_url }}"
+        }
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {% for crumb in breadcrumbs %}
+          {
+            "@type": "ListItem",
+            "position": {{ loop.index }},
+            "name": "{{ crumb.label }}"{% if crumb.url %},
+            "item": "{{ site.base_url }}{{ crumb.url|replace(site.base_path, '') }}"{% endif %}
+          }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        ]
+      }
+    ]
   }
 </script>
 {% endblock %} {% block content %} {% include "components/breadcrumb.html" %}

--- a/crates/lintel-catalog-builder/src/html/templates/schemas_index.html
+++ b/crates/lintel-catalog-builder/src/html/templates/schemas_index.html
@@ -1,0 +1,62 @@
+{% extends "layout.html" %} {% block title %}All JSON Schemas - {{ site.title
+}}{% endblock %} {% block description %}{{ seo_description }}{% endblock %} {%
+block canonical %}{{ site.base_url }}schemas/{% endblock %} {% block og_title
+%}All JSON Schemas - {{ site.title }}{% endblock %} {% block og_description %}{{
+seo_description }}{% endblock %} {% block og_url %}{{ site.base_url }}schemas/{%
+endblock %} {% block jsonld %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        "name": "All JSON Schemas",
+        "description": "{{ seo_description }}",
+        "url": "{{ site.base_url }}schemas/",
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "{{ site.title }}",
+          "url": "{{ site.base_url }}"
+        }
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "{{ site.base_url }}"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "All Schemas"
+          }
+        ]
+      }
+    ]
+  }
+</script>
+{% endblock %} {% block content %}
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="{{ site.base_path }}">Home</a>
+  <span class="breadcrumb-sep" aria-hidden="true">/</span>
+  <span class="breadcrumb-current" aria-current="page">All Schemas</span>
+</nav>
+
+<article>
+  <header class="page-header">
+    <h1>All Schemas</h1>
+    <p class="page-description">
+      Complete listing of all {{ schemas|length|commafy }} JSON Schemas in the
+      catalog.
+    </p>
+  </header>
+
+  <div class="schema-list">
+    {% for schema in schemas %} {% include "components/schema_card.html" %} {%
+    endfor %}
+  </div>
+</article>
+{% endblock %}

--- a/crates/lintel-catalog-builder/src/html/templates/shared.html
+++ b/crates/lintel-catalog-builder/src/html/templates/shared.html
@@ -1,10 +1,26 @@
 {% extends "layout.html" %} {% block title %}{{ name }} - {{ site.title }}{%
-endblock %} {% block description %}Shared dependency schema: {{ name }}{%
+endblock %} {% block description %}Shared dependency schema: {{ name }}.{%
 endblock %} {% block canonical %}{{ site.base_url }}{{ name }}{% endblock %} {%
 block og_title %}{{ name }} - {{ site.title }}{% endblock %} {% block
-og_description %}Shared dependency schema: {{ name }}{% endblock %} {% block
-og_url %}{{ site.base_url }}{{ name }}{% endblock %} {% block content %} {%
-include "components/breadcrumb.html" %}
+og_description %}Shared dependency schema: {{ name }}.{% endblock %} {% block
+og_url %}{{ site.base_url }}{{ name }}{% endblock %} {% block jsonld %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {% for crumb in breadcrumbs %}
+      {
+        "@type": "ListItem",
+        "position": {{ loop.index }},
+        "name": "{{ crumb.label }}"{% if crumb.url %},
+        "item": "{{ site.base_url }}{{ crumb.url|replace(site.base_path, '') }}"{% endif %}
+      }{% if not loop.last %},{% endif %}
+      {% endfor %}
+    ]
+  }
+</script>
+{% endblock %} {% block content %} {% include "components/breadcrumb.html" %}
 
 <div class="schema-layout">
   <article class="schema-detail">

--- a/crates/lintel-catalog-builder/src/html/templates/sitemap.xml
+++ b/crates/lintel-catalog-builder/src/html/templates/sitemap.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url><loc>{{ base_url }}</loc></url>
+    <url>
+        <loc>{{ base_url }}</loc>
+        <lastmod>{{ lastmod }}</lastmod>
+    </url>
     {% for url in urls %}
-    <url><loc>{{ base_url }}{{ url }}</loc></url>
+    <url>
+        <loc>{{ base_url }}{{ url }}</loc>
+        <lastmod>{{ lastmod }}</lastmod>
+    </url>
     {% endfor %}
 </urlset>

--- a/crates/lintel-catalog-builder/src/html/templates/style.css
+++ b/crates/lintel-catalog-builder/src/html/templates/style.css
@@ -200,11 +200,8 @@ a:hover {
   display: block;
 }
 
-/* Home header (compact, lib.rs-inspired) */
+/* Home header */
 .home-header {
-  display: flex;
-  align-items: baseline;
-  gap: 1rem;
   padding: 1rem 0 0.75rem;
   border-bottom: 1px solid var(--border);
   margin-bottom: 1rem;
@@ -212,9 +209,18 @@ a:hover {
 .home-header h1 {
   font-size: 1.25rem;
   font-weight: 700;
+  margin-bottom: 0.5rem;
 }
-.home-stats {
-  font-size: 0.85rem;
+.home-intro {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+.section-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 1rem 0 0.75rem;
   color: var(--text-muted);
 }
 

--- a/crates/lintel-catalog-builder/src/html/templates/version.html
+++ b/crates/lintel-catalog-builder/src/html/templates/version.html
@@ -1,25 +1,44 @@
 {% extends "layout.html" %} {% block title %}{{ schema_name }} {{ version_name
-}} - {{ site.title }}{% endblock %} {% block description %}Version {{
-version_name }} of {{ schema_name }}{% endblock %} {% block canonical %}{{
-site.base_url }}{{ page_url }}{% endblock %} {% block og_title %}{{ schema_name
-}} {{ version_name }} - {{ site.title }}{% endblock %} {% block og_description
-%}Version {{ version_name }} of {{ schema_name }}{% endblock %} {% block og_url
-%}{{ site.base_url }}{{ page_url }}{% endblock %} {% block jsonld %}
+}}{% if group_name %} ({{ group_name }}){% endif %} JSON Schema - {{ site.title
+}}{% endblock %} {% block description %}Version {{ version_name }} of the {{
+schema_name }} JSON Schema.{% endblock %} {% block canonical %}{{ site.base_url
+}}{{ page_url }}{% endblock %} {% block og_title %}{{ schema_name }} {{
+version_name }}{% if group_name %} ({{ group_name }}){% endif %} JSON Schema -
+{{ site.title }}{% endblock %} {% block og_description %}Version {{ version_name
+}} of the {{ schema_name }} JSON Schema.{% endblock %} {% block og_url %}{{
+site.base_url }}{{ page_url }}{% endblock %} {% block jsonld %}
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "SoftwareSourceCode",
-    "name": "{{ schema_name }} {{ version_name }}",
-    "description": "Version {{ version_name }} of {{ schema_name }}",
-    "url": "{{ site.base_url }}{{ page_url }}",
-    "codeRepository": "{{ json_url }}",
-    "programmingLanguage": "JSON Schema",
-    "version": "{{ version_name }}",
-    "isPartOf": {
-      "@type": "WebSite",
-      "name": "{{ site.title }}",
-      "url": "{{ site.base_url }}"
-    }
+    "@graph": [
+      {
+        "@type": "SoftwareSourceCode",
+        "name": "{{ schema_name }} {{ version_name }}",
+        "description": "Version {{ version_name }} of {{ schema_name }}",
+        "url": "{{ site.base_url }}{{ page_url }}",
+        "codeRepository": "{{ json_url }}",
+        "programmingLanguage": "JSON Schema",
+        "version": "{{ version_name }}",
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "{{ site.title }}",
+          "url": "{{ site.base_url }}"
+        }
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {% for crumb in breadcrumbs %}
+          {
+            "@type": "ListItem",
+            "position": {{ loop.index }},
+            "name": "{{ crumb.label }}"{% if crumb.url %},
+            "item": "{{ site.base_url }}{{ crumb.url|replace(site.base_path, '') }}"{% endif %}
+          }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        ]
+      }
+    ]
   }
 </script>
 {% endblock %} {% block content %} {% include "components/breadcrumb.html" %}

--- a/crates/lintel-catalog-builder/src/targets/mod.rs
+++ b/crates/lintel-catalog-builder/src/targets/mod.rs
@@ -24,6 +24,8 @@ pub struct OutputContext<'a> {
     pub site_description: Option<&'a str>,
     /// Optional Google Analytics tracking ID from the target's site config.
     pub ga_tracking_id: Option<&'a str>,
+    /// Optional Open Graph image URL from the target's site config.
+    pub og_image: Option<&'a str>,
 }
 
 /// Resolve the output directory for a target.
@@ -239,6 +241,7 @@ mod tests {
             processed: &processed,
             site_description: None,
             ga_tracking_id: None,
+            og_image: None,
         };
         write_readme(&ctx).await?;
         let content = tokio::fs::read_to_string(dir.path().join("README.md")).await?;
@@ -265,6 +268,7 @@ mod tests {
             processed: &processed,
             site_description: None,
             ga_tracking_id: None,
+            og_image: None,
         };
         let target = TargetConfig {
             dir: "out".into(),
@@ -272,6 +276,7 @@ mod tests {
             site: Some(SiteConfig {
                 description: None,
                 ga_tracking_id: None,
+                og_image: None,
                 github: Some(GitHubPagesConfig {
                     cname: Some("example.com".into()),
                 }),
@@ -301,6 +306,7 @@ mod tests {
             processed: &processed,
             site_description: None,
             ga_tracking_id: None,
+            og_image: None,
         };
         let target = TargetConfig {
             dir: "out".into(),


### PR DESCRIPTION
## Summary
- Add `robots.txt` generation pointing to sitemap
- Add `BreadcrumbList` JSON-LD structured data on all pages for Google rich results
- Add `og:image` and Twitter Card (`twitter:card`, `twitter:title`, `twitter:description`) meta tags with configurable `og-image` site config option
- Improve page titles to include group name and "JSON Schema" keywords (e.g. "Configuration (Biome) JSON Schema - Lintel Catalog")
- Add `<lastmod>` timestamps to all sitemap entries
- Improve meta descriptions: front-load tool name, file patterns, and useful info instead of boilerplate
- Add intro paragraph to home page with proper heading hierarchy (`h1` → `h2` → `h3`)
- Add new `/schemas/` index page listing all schemas in a flat view

## Test plan
- [x] All 57 `lintel-catalog-builder` tests pass
- [x] Full workspace builds and all tests pass (0 failures)
- [x] Clippy, rustfmt, prettier pre-commit hooks pass