### PR TITLE
Add semver crate to workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,6 +2821,7 @@ dependencies = [
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
+ "semver",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ insta = { version = "1.46.3", features = ["filters"] }
 jsonschema = "0.42.2"
 miette = "7.6.0"
 reqwest = { version = "0.13.2", default-features = false, features = ["rustls"] }
-schemars = "1.2.1"
+schemars = { version = "1.2.1", features = ["semver1"] }
+semver = "1.0.27"
 serde = "1.0.228"
 serde_json = "1.0.149"
 tempfile = "3.26.0"

--- a/crates/lintel-catalog-builder/Cargo.toml
+++ b/crates/lintel-catalog-builder/Cargo.toml
@@ -27,7 +27,7 @@ pulldown-cmark = { version = "0.13.1", default-features = false, features = ["ht
 reqwest.workspace = true
 schema-catalog = { version = "0.0.8", path = "../schema-catalog" }
 schemars.workspace = true
-semver = "1.0.27"
+semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "process"] }

--- a/crates/lintel-format/Cargo.toml
+++ b/crates/lintel-format/Cargo.toml
@@ -28,7 +28,7 @@ ignore.workspace = true
 lintel-config = { version = "0.0.7", path = "../lintel-config" }
 miette = { workspace = true, features = ["fancy"] }
 pretty_yaml = "0.6.0"
-semver = "1.0.27"
+semver.workspace = true
 serde_json.workspace = true
 similar = "2.7.0"
 thiserror.workspace = true

--- a/crates/lintel-validate/Cargo.toml
+++ b/crates/lintel-validate/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1.89"
-percent-encoding = "2.3.2"
 bpaf.workspace = true
 glob.workspace = true
 glob-match.workspace = true
@@ -29,6 +28,7 @@ lintel-config = { version = "0.0.7", path = "../lintel-config" }
 lintel-schema-cache = { version = "0.0.12", path = "../lintel-schema-cache" }
 lintel-validation-cache = { version = "0.0.8", path = "../lintel-validation-cache" }
 miette = { workspace = true, features = ["fancy"] }
+percent-encoding = "2.3.2"
 schema-catalog = { version = "0.0.8", path = "../schema-catalog" }
 serde_json.workspace = true
 serde_yaml = "0.9.34"

--- a/crates/schema-catalog/Cargo.toml
+++ b/crates/schema-catalog/Cargo.toml
@@ -15,6 +15,6 @@ workspace = true
 
 [dependencies]
 glob-set = { version = "0.1.0", path = "../glob-set" }
-schemars = { version = "1.2.1", default-features = false, features = ["derive"] }
+schemars = { version = "1.2.1", default-features = false, features = ["derive", "semver1"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.149", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
## Summary
- Adds `semver = "1.0.27"` to workspace dependencies and enables the `semver1` feature on `schemars` so `semver::Version` gets a `JsonSchema` implementation
- Updates `lintel-catalog-builder` and `lintel-format` to use `semver.workspace = true` instead of local pins
- Adds `semver1` feature to `schema-catalog`'s schemars dependency

## Test plan
- [x] `cargo check` passes across the full workspace