### PR TITLE
Replace flake-utils with flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1771438068,
-        "narHash": "sha256-nGBbXvEZVe/egCPVPFcu89RFtd8Rf6J+4RFoVCFec0A=",
+        "lastModified": 1772080396,
+        "narHash": "sha256-84W9UNtSk9DNMh43WBkOjpkbfODlmg+RDi854PnNgLE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b5090e53e9d68c523a4bb9ad42b4737ee6747597",
+        "rev": "8525580bc0316c39dbfa18bd09a1331e98c9e463",
         "type": "github"
       },
       "original": {
@@ -15,31 +15,31 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771423170,
-        "narHash": "sha256-K7Dg9TQ0mOcAtWTO/FX/FaprtWQ8BmEXTpLIaNRhEwU=",
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcc4a9d9533c033d806a46b37dc444f9b0da49dd",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
         "type": "github"
       },
       "original": {
@@ -49,26 +49,26 @@
         "type": "github"
       }
     },
-    "root": {
-      "inputs": {
-        "crane": "crane",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,65 +4,70 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      crane,
-      flake-utils,
+    inputs@{
+      flake-parts,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        craneLib = crane.mkLib pkgs;
-        craneLibStatic =
-          if pkgs.stdenv.isLinux then
-            let
-              muslPkgs =
-                {
-                  "x86_64-linux" = pkgs.pkgsCross.musl64;
-                  "aarch64-linux" = pkgs.pkgsCross.aarch64-multiplatform-musl;
-                }
-                .${system};
-            in
-            crane.mkLib muslPkgs
-          else
-            null;
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
 
-        packages = import ./nix/packages.nix {
-          inherit
-            craneLib
-            craneLibStatic
-            pkgs
-            ;
-        };
-      in
-      {
-        checks = {
-          inherit (packages) lintel;
-        };
+      perSystem =
+        {
+          self',
+          pkgs,
+          system,
+          ...
+        }:
+        let
+          craneLib = inputs.crane.mkLib pkgs;
+          craneLibStatic =
+            if pkgs.stdenv.isLinux then
+              let
+                muslPkgs =
+                  {
+                    "x86_64-linux" = pkgs.pkgsCross.musl64;
+                    "aarch64-linux" = pkgs.pkgsCross.aarch64-multiplatform-musl;
+                  }
+                  .${system};
+              in
+              inputs.crane.mkLib muslPkgs
+            else
+              null;
 
-        packages =
-          packages
-          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-            docker = import ./nix/docker.nix {
-              inherit pkgs;
-              lintel = packages.lintel;
-            };
+          packages = import ./nix/packages.nix {
+            inherit
+              craneLib
+              craneLibStatic
+              pkgs
+              ;
+          };
+        in
+        {
+          checks = {
+            inherit (packages) lintel;
           };
 
-        apps.default = flake-utils.lib.mkApp {
-          drv = packages.default;
-        };
+          packages =
+            packages
+            // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+              docker = import ./nix/docker.nix {
+                inherit pkgs;
+                lintel = packages.lintel;
+              };
+            };
 
-        devShells.default = craneLib.devShell {
-          checks = self.checks.${system};
+          devShells.default = craneLib.devShell {
+            checks = self'.checks;
+          };
         };
-      }
-    );
+    };
 }


### PR DESCRIPTION
## Summary
- Replace `flake-utils` with `flake-parts` as the flake framework
- Use `mkFlake` + `perSystem` instead of `eachDefaultSystem`
- Use idiomatic `self'` for system-scoped references instead of `self.checks.${system}`
- Drop redundant `apps.default` output (`nix run` already picks `packages.default`)

## Test plan
- [x] `nix flake check` passes
- [x] `nix build` produces lintel binary