### PR TITLE
Render additionalProperties as Record<key, Value> in schema docs

### DIFF
--- a/crates/lintel-catalog-builder/src/html/templates/components/property_tree.html
+++ b/crates/lintel-catalog-builder/src/html/templates/components/property_tree.html
@@ -11,7 +11,17 @@
 >
   <div class="property-header">
     <span class="property-name">{{ property.name }}</span>
-    {% if property.schema_type_parts %}
+    {% if property.additional_properties %}
+    <span class="type-badge"
+      >Record&lt;{{ property.additional_properties.key_label }}, {% if
+      property.additional_properties.value_href %}<a
+        href="{{ property.additional_properties.value_href }}"
+        class="type-badge-link"
+        >{{ property.additional_properties.value_type }}</a
+      >{% else %}{{ property.additional_properties.value_type }}{% endif
+      %}&gt;</span
+    >
+    {% elif property.schema_type_parts %}
     <span class="type-badge"
       >{% for part in property.schema_type_parts %}{% if part.href %}<a
         href="{{ part.href }}"

--- a/crates/lintel-catalog-builder/src/html/templates/components/schema_doc.html
+++ b/crates/lintel-catalog-builder/src/html/templates/components/schema_doc.html
@@ -77,7 +77,15 @@
   <div class="definition-block" id="{{ def.slug }}">
     <div class="definition-header">
       <span class="def-name">{{ def.name }}</span>
-      {% if def.schema_type %}<span class="type-badge"
+      {% if def.additional_properties %}<span class="type-badge"
+        >Record&lt;{{ def.additional_properties.key_label }}, {% if
+        def.additional_properties.value_href %}<a
+          href="{{ def.additional_properties.value_href }}"
+          class="type-badge-link"
+          >{{ def.additional_properties.value_type }}</a
+        >{% else %}{{ def.additional_properties.value_type }}{% endif
+        %}&gt;</span
+      >{% elif def.schema_type %}<span class="type-badge"
         >{{ def.schema_type }}</span
       >{% endif %}
     </div>


### PR DESCRIPTION
## Summary
- Properties and definitions with `additionalProperties` schemas now display as `Record<key, Value>` type badges instead of plain `object`
- The value type is clickable when it references a local `$defs` definition or external catalog schema page
- Supports `x-tombi-additional-key-label` extension for custom key names (e.g. `crate_name` instead of `string`)
- Boolean `additionalProperties` (`true`/`false`) are ignored since they don't convey type info

## Test plan
- [x] All 86 existing tests pass
- [x] 5 new tests added covering: local ref, no ref, boolean ignored, external ref, definition with additionalProperties
- [ ] Verify on catalog.lintel.tools that `dependencies` in cargo-manifest schema renders as `Record<crate_name, Dependency>` with clickable link to `#def-Dependency`