### PR TITLE
Fix explain title: use filename without uppercasing

### DIFF
--- a/crates/jsonschema-explain/src/lib.rs
+++ b/crates/jsonschema-explain/src/lib.rs
@@ -53,9 +53,12 @@ pub fn explain(schema: &Value, name: &str, opts: &ExplainOptions) -> String {
     let title = schema.get("title").and_then(Value::as_str);
     let description = get_description(schema);
 
-    let upper = name.to_uppercase();
-    let center = title.unwrap_or(name);
-    let header = format_header(&upper, center, opts.width);
+    let label = std::path::Path::new(name)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(name);
+    let center = title.unwrap_or(label);
+    let header = format_header(label, center, opts.width);
     let _ = writeln!(out, "{}{header}{}\n", f.bold, f.reset);
 
     if !opts.validation_errors.is_empty() {
@@ -689,8 +692,8 @@ mod tests {
 
         let output = explain(&schema, "fallback-name", &plain());
         assert!(!output.contains("TITLE"));
-        // display name still appears in the header banner
-        assert!(output.contains("FALLBACK-NAME"));
+        // display name still appears in the header banner (not uppercased)
+        assert!(output.contains("fallback-name"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The `lintel explain` header banner was showing the full path uppercased (e.g. `TSCONFIG.JSON`)
- Now extracts just the filename and displays it as-is (e.g. `tsconfig.json`)

## Test plan
- [x] All 55 `jsonschema-explain` tests pass
- [ ] Verify `lintel explain --path tsconfig.json` shows `tsconfig.json` in the header (not `TSCONFIG.JSON`)