### PR TITLE
Refactor jsonschema-schema extensions and use BTreeMap

### DIFF
--- a/crates/jsonschema-explain/src/sections.rs
+++ b/crates/jsonschema-explain/src/sections.rs
@@ -94,44 +94,30 @@ pub(crate) fn render_definitions_section(
     root: &SchemaValue,
     f: &Fmt<'_>,
 ) {
-    // Check $defs (typed field) and definitions (in extra)
-    let defs_sources: Vec<(&str, &indexmap::IndexMap<String, SchemaValue>)> = {
-        let mut sources = Vec::new();
-        if let Some(ref defs) = schema.defs {
-            sources.push(("$defs", defs));
-        }
-        sources
-    };
-
-    // Also check "definitions" in extra (pre-2020-12 schemas might have it)
-    let definitions_value = schema.extra.get("definitions");
-    let definitions_map: Option<indexmap::IndexMap<String, SchemaValue>> =
-        definitions_value.and_then(|v| serde_json::from_value(v.clone()).ok());
-
-    for (_, defs) in &defs_sources {
-        render_defs_block(out, defs, root, f);
-    }
-
-    if let Some(ref defs) = definitions_map
+    if let Some(ref defs) = schema.defs
         && !defs.is_empty()
     {
-        render_defs_block(out, defs, root, f);
+        render_defs_block(out, defs.iter(), root, f);
+    }
+
+    // Also check "definitions" in extra (pre-2020-12 schemas might have it)
+    if let Some(defs) = schema.extra.get("definitions").and_then(|v| {
+        serde_json::from_value::<indexmap::IndexMap<String, SchemaValue>>(v.clone()).ok()
+    }) && !defs.is_empty()
+    {
+        render_defs_block(out, defs.iter(), root, f);
     }
 }
 
-fn render_defs_block(
+fn render_defs_block<'a>(
     out: &mut String,
-    defs: &indexmap::IndexMap<String, SchemaValue>,
+    defs: impl Iterator<Item = (&'a String, &'a SchemaValue)>,
     root: &SchemaValue,
     f: &Fmt<'_>,
 ) {
-    if defs.is_empty() {
-        return;
-    }
-
     write_section(out, "DEFINITIONS", f);
     // Sort deprecated definitions to the end.
-    let mut sorted_defs: Vec<_> = defs.iter().collect();
+    let mut sorted_defs: Vec<_> = defs.collect();
     sorted_defs.sort_by_key(|(_, sv)| i32::from(sv.as_schema().is_some_and(Schema::is_deprecated)));
     for (def_name, def_sv) in sorted_defs {
         let Some(def_schema) = def_sv.as_schema() else {

--- a/crates/jsonschema-schema/README.md
+++ b/crates/jsonschema-schema/README.md
@@ -1,0 +1,125 @@
+# jsonschema-schema
+
+[![Crates.io](https://img.shields.io/crates/v/jsonschema-schema.svg)](https://crates.io/crates/jsonschema-schema)
+[![docs.rs](https://docs.rs/jsonschema-schema/badge.svg)](https://docs.rs/jsonschema-schema)
+[![GitHub](https://img.shields.io/github/stars/lintel-rs/lintel?style=flat)](https://github.com/lintel-rs/lintel)
+[![License](https://img.shields.io/crates/l/jsonschema-schema.svg)](https://github.com/lintel-rs/lintel/blob/master/LICENSE)
+
+Typed Rust structs for JSON Schema (draft 2020-12) documents. Part of the
+[Lintel](https://github.com/lintel-rs/lintel) project.
+
+Unlike raw `serde_json::Value`, this crate gives you named fields for every
+standard keyword — `properties`, `items`, `allOf`, `$ref`, `format`, and so
+on — so you can pattern-match and navigate schemas without string lookups.
+
+## Features
+
+- **Strongly typed** — `Schema`, `SchemaValue` (object or boolean), and
+  `TypeValue` (single or union) with full serde round-tripping
+- **All standard keywords** — core identifiers, metadata, validation,
+  applicators, composition, conditionals, content, and dependencies
+- **Editor extensions** — first-class `x-taplo`, `x-tombi-*`, and `x-lintel`
+  extension structs
+- **Catch-all** — unknown properties are preserved in `extra: IndexMap<String, Value>`
+- **Pointer navigation** — `navigate_pointer` walks a JSON Pointer path
+  through nested schemas, resolving `$ref` along the way
+- **Helper utilities** — `ref_name`, `resolve_ref`, `Schema::type_str`,
+  `Schema::description`, and more
+
+## Usage
+
+### Parsing a schema from JSON
+
+```rust
+use jsonschema_schema::{Schema, SchemaValue, TypeValue};
+
+let json = serde_json::json!({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "User",
+    "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer", "minimum": 0 }
+    },
+    "required": ["name"]
+});
+
+let schema: Schema = serde_json::from_value(json).unwrap();
+
+assert_eq!(schema.title.as_deref(), Some("User"));
+assert_eq!(schema.required_set(), &["name"]);
+
+// type_str() produces a human-readable summary
+assert_eq!(schema.type_str().as_deref(), Some("object"));
+
+// Access a nested property schema
+let name_sv = schema.properties.as_ref().unwrap().get("name").unwrap();
+let name = name_sv.as_schema().unwrap();
+assert!(matches!(name.type_, Some(TypeValue::Single(ref t)) if t == "string"));
+```
+
+### Building a schema programmatically
+
+```rust
+use jsonschema_schema::{Schema, SchemaValue, TypeValue};
+use indexmap::IndexMap;
+
+let mut props = IndexMap::new();
+props.insert("email".to_string(), SchemaValue::Schema(Box::new(Schema {
+    type_: Some(TypeValue::Single("string".into())),
+    format: Some("email".into()),
+    ..Default::default()
+})));
+
+let schema = Schema {
+    type_: Some(TypeValue::Single("object".into())),
+    properties: Some(props),
+    required: Some(vec!["email".into()]),
+    ..Default::default()
+};
+
+let json = serde_json::to_value(&schema).unwrap();
+assert_eq!(json["required"], serde_json::json!(["email"]));
+assert_eq!(json["properties"]["email"]["format"], "email");
+```
+
+### Navigating with JSON Pointers
+
+`navigate_pointer` resolves a [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901)
+JSON Pointer through the typed schema tree, automatically following `$ref`
+references within the same document.
+
+```rust
+use jsonschema_schema::{Schema, SchemaValue, TypeValue, navigate_pointer};
+use std::collections::BTreeMap;
+
+// Build a schema with $defs and a $ref
+let item = SchemaValue::Schema(Box::new(Schema {
+    type_: Some(TypeValue::Single("string".into())),
+    ..Default::default()
+}));
+let mut defs = BTreeMap::new();
+defs.insert("Tag".to_string(), item);
+
+let root = SchemaValue::Schema(Box::new(Schema {
+    defs: Some(defs),
+    ..Default::default()
+}));
+
+let result = navigate_pointer(&root, &root, "/$defs/Tag").unwrap();
+let tag = result.as_schema().unwrap();
+assert_eq!(tag.type_str().as_deref(), Some("string"));
+```
+
+### Extracting a ref name
+
+```rust
+use jsonschema_schema::ref_name;
+
+assert_eq!(ref_name("#/$defs/Address"), "Address");
+assert_eq!(ref_name("./other.json"), "other.json");
+```
+
+## License
+
+Apache-2.0

--- a/crates/jsonschema-schema/src/ext_tombi.rs
+++ b/crates/jsonschema-schema/src/ext_tombi.rs
@@ -1,3 +1,0 @@
-// x-tombi-* extension types are represented as fields directly on Schema
-// (x-tombi-toml-version, x-tombi-table-keys-order, etc.)
-// This module is reserved for future structured Tombi extension types.

--- a/crates/jsonschema-schema/src/extensions/lintel.rs
+++ b/crates/jsonschema-schema/src/extensions/lintel.rs
@@ -1,4 +1,5 @@
-use indexmap::IndexMap;
+use alloc::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -11,5 +12,5 @@ pub struct LintelExt {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_sha256: Option<String>,
     #[serde(flatten)]
-    pub extra: IndexMap<String, Value>,
+    pub extra: BTreeMap<String, Value>,
 }

--- a/crates/jsonschema-schema/src/extensions/mod.rs
+++ b/crates/jsonschema-schema/src/extensions/mod.rs
@@ -1,0 +1,7 @@
+mod lintel;
+mod taplo;
+mod tombi;
+
+pub use lintel::LintelExt;
+pub use taplo::{ExtDocs, ExtLinks, TaploInfo, TaploSchemaExt};
+pub use tombi::TombiExt;

--- a/crates/jsonschema-schema/src/extensions/taplo.rs
+++ b/crates/jsonschema-schema/src/extensions/taplo.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 /// Taplo JSON Schema extension (`x-taplo`).
+///
+/// Controls editor behavior in the Taplo TOML language server: documentation
+/// text, completion links, hidden fields, and plugins.
+///
 /// Compatible with taplo-common's `TaploSchemaExt`.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
@@ -17,6 +21,7 @@ pub struct TaploSchemaExt {
     pub plugins: Vec<String>,
 }
 
+/// Documentation text overrides for Taplo hover/completion.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtDocs {
@@ -30,6 +35,7 @@ pub struct ExtDocs {
     pub enum_values: Option<Vec<Option<String>>>,
 }
 
+/// Link targets for Taplo navigation.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtLinks {
@@ -37,4 +43,24 @@ pub struct ExtLinks {
     pub key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_values: Option<Vec<Option<String>>>,
+}
+
+/// Taplo schema catalog metadata (`x-taplo-info`).
+///
+/// Embeds file-association patterns, authorship, and version information
+/// directly inside a schema file. Used by Taplo's built-in catalog to
+/// match schemas to TOML files without a separate catalog entry.
+///
+/// Compatible with taplo-common's `TaploSchemaExtraInfo`.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct TaploInfo {
+    /// Schema author credits, typically `"Name (url)"`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authors: Vec<String>,
+    /// Semver version of the schema or the tool it describes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Regex patterns matching file paths this schema applies to.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub patterns: Vec<String>,
 }

--- a/crates/jsonschema-schema/src/extensions/tombi.rs
+++ b/crates/jsonschema-schema/src/extensions/tombi.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Tombi JSON Schema extensions (`x-tombi-*`).
+///
+/// Unlike `x-taplo` (a single nested object), Tombi extensions are separate
+/// top-level keys on the schema. This struct is flattened into `Schema` so
+/// the individual `x-tombi-*` keys serialize/deserialize correctly.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TombiExt {
+    #[serde(
+        rename = "x-tombi-toml-version",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub toml_version: Option<String>,
+    #[serde(
+        rename = "x-tombi-table-keys-order",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub table_keys_order: Option<Value>,
+    #[serde(
+        rename = "x-tombi-additional-key-label",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_key_label: Option<String>,
+    #[serde(
+        rename = "x-tombi-array-values-order",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub array_values_order: Option<Value>,
+}

--- a/crates/jsonschema-schema/src/lib.rs
+++ b/crates/jsonschema-schema/src/lib.rs
@@ -1,8 +1,9 @@
-mod ext_lintel;
-mod ext_taplo;
-mod ext_tombi;
+#![doc = include_str!("../README.md")]
+
+extern crate alloc;
+
+pub mod extensions;
 mod schema;
 
-pub use ext_lintel::LintelExt;
-pub use ext_taplo::{ExtDocs, ExtLinks, TaploSchemaExt};
+pub use extensions::{ExtDocs, ExtLinks, LintelExt, TaploInfo, TaploSchemaExt, TombiExt};
 pub use schema::{Schema, SchemaValue, TypeValue, navigate_pointer, ref_name, resolve_ref};

--- a/crates/jsonschema-schema/src/schema.rs
+++ b/crates/jsonschema-schema/src/schema.rs
@@ -1,9 +1,13 @@
+use alloc::collections::BTreeMap;
+
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::ext_lintel::LintelExt;
-use crate::ext_taplo::TaploSchemaExt;
+use crate::extensions::LintelExt;
+use crate::extensions::TaploInfo;
+use crate::extensions::TaploSchemaExt;
+use crate::extensions::TombiExt;
 
 /// A JSON Schema value — either a boolean schema or an object schema.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +33,19 @@ pub struct Schema {
     pub schema: Option<String>,
     #[serde(rename = "$id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(
+        rename = "markdownDescription",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub markdown_description: Option<String>,
+    #[serde(rename = "x-lintel", skip_serializing_if = "Option::is_none")]
+    pub x_lintel: Option<LintelExt>,
+
     #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
     pub ref_: Option<String>,
     #[serde(rename = "$anchor", skip_serializing_if = "Option::is_none")]
@@ -40,18 +57,9 @@ pub struct Schema {
     #[serde(rename = "$comment", skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
     #[serde(rename = "$defs", skip_serializing_if = "Option::is_none")]
-    pub defs: Option<IndexMap<String, SchemaValue>>,
+    pub defs: Option<BTreeMap<String, SchemaValue>>,
 
     // --- Metadata ---
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(
-        rename = "markdownDescription",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub markdown_description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -169,37 +177,16 @@ pub struct Schema {
     #[serde(rename = "contentSchema", skip_serializing_if = "Option::is_none")]
     pub content_schema: Option<Box<SchemaValue>>,
 
-    // --- Extensions ---
     #[serde(rename = "x-taplo", skip_serializing_if = "Option::is_none")]
     pub x_taplo: Option<TaploSchemaExt>,
     #[serde(rename = "x-taplo-info", skip_serializing_if = "Option::is_none")]
-    pub x_taplo_info: Option<Value>,
-    #[serde(rename = "x-lintel", skip_serializing_if = "Option::is_none")]
-    pub x_lintel: Option<LintelExt>,
-    #[serde(
-        rename = "x-tombi-toml-version",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub x_tombi_toml_version: Option<String>,
-    #[serde(
-        rename = "x-tombi-table-keys-order",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub x_tombi_table_keys_order: Option<Value>,
-    #[serde(
-        rename = "x-tombi-additional-key-label",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub x_tombi_additional_key_label: Option<String>,
-    #[serde(
-        rename = "x-tombi-array-values-order",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub x_tombi_array_values_order: Option<Value>,
+    pub x_taplo_info: Option<TaploInfo>,
+    #[serde(flatten)]
+    pub x_tombi: TombiExt,
 
     // --- Catch-all for unknown properties ---
     #[serde(flatten)]
-    pub extra: IndexMap<String, Value>,
+    pub extra: BTreeMap<String, Value>,
 }
 
 impl SchemaValue {
@@ -568,7 +555,11 @@ impl Schema {
                     .as_ref()
                     .and_then(|m| m.get(segment))
             })
-            .or_else(|| self.defs.as_ref().and_then(|m| m.get(segment)))
+            .or_else(|| {
+                self.defs
+                    .as_ref()
+                    .and_then(|m: &BTreeMap<String, SchemaValue>| m.get(segment))
+            })
             .or_else(|| self.dependent_schemas.as_ref().and_then(|m| m.get(segment)))
     }
 }
@@ -802,7 +793,7 @@ mod tests {
             ref_: Some("#/$defs/Item".into()),
             ..Default::default()
         }));
-        let mut defs = IndexMap::new();
+        let mut defs = BTreeMap::new();
         defs.insert("Item".into(), item_schema);
         let mut props = IndexMap::new();
         props.insert("item".into(), ref_schema);


### PR DESCRIPTION
## Summary

- Restructure extension types into `src/extensions/` module with separate files for lintel, taplo, and tombi
- Consolidate four individual `x-tombi-*` fields into a flattened `TombiExt` struct
- Type `x-taplo-info` as a proper `TaploInfo` struct (authors, version, patterns) instead of raw `Value`
- Change `defs` and `extra` fields from `IndexMap` to `BTreeMap` for deterministic sorted serialization
- Reorder `Schema` fields so `title`, `description`, `markdownDescription`, and `x-lintel` serialize right after `$id`
- Add comprehensive README with 4 passing doctests
- Simplify `render_defs_block` to accept a generic iterator

## Test plan

- [x] `cargo test -p jsonschema-schema` — 23 unit tests + 4 doctests pass
- [x] `cargo test -p jsonschema-explain` — 54 unit tests + 1 doctest pass
- [x] `cargo clippy --workspace` — no warnings
- [x] Pre-commit hooks (clippy, rustfmt, prettier) pass