### PR TITLE
feat: granular validation error codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strum",
  "tempfile",
  "tokio",
 ]
@@ -3055,6 +3056,27 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "sublime-syntaxes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { version = "0.13.2", default-features = false, features = ["rustls"] 
 schemars = { version = "1.2.1", features = ["semver1"] }
 semver = "1.0.27"
 serde = "1.0.228"
+strum = { version = "0.27.1", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.26.0"
 thiserror = "2.0.18"

--- a/crates/lintel-diagnostics/src/diagnostics.rs
+++ b/crates/lintel-diagnostics/src/diagnostics.rs
@@ -1,9 +1,71 @@
-use miette::{Diagnostic, NamedSource, SourceSpan};
+use miette::{Diagnostic, LabeledSpan, NamedSource, SourceSpan};
 use thiserror::Error;
 
 /// Default label text used for span annotations when no specific instance path
 /// is available. Checked by reporters to decide whether to show the path suffix.
 pub const DEFAULT_LABEL: &str = "here";
+
+/// A validation diagnostic with a granular error code (e.g. `lintel::validation::required`).
+///
+/// Implements [`Diagnostic`] manually so the code can be computed at runtime
+/// from the [`ValidationErrorKind`](lintel_validation_cache::ValidationErrorKind).
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct ValidationDiagnostic {
+    pub src: NamedSource<String>,
+    pub span: SourceSpan,
+    pub schema_span: SourceSpan,
+    pub path: String,
+    pub instance_path: String,
+    pub label: String,
+    pub message: String,
+    /// Schema URI this file was validated against (shown as a clickable link
+    /// in terminals for remote schemas).
+    pub schema_url: String,
+    /// JSON Schema path that triggered the error (e.g. `/properties/jobs/oneOf`).
+    pub schema_path: String,
+    /// Granular diagnostic code (e.g. `lintel::validation::required`).
+    pub validation_code: String,
+}
+
+impl Diagnostic for ValidationDiagnostic {
+    fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        Some(Box::new(&self.validation_code))
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        Some(Box::new(&self.schema_url))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        Some(Box::new(format!(
+            "run `lintel explain --file {}` to see the full schema definition",
+            self.path
+        )))
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.src)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        Some(Box::new(
+            [
+                LabeledSpan::new(
+                    Some(self.label.clone()),
+                    self.span.offset(),
+                    self.span.len(),
+                ),
+                LabeledSpan::new(
+                    Some(format!("from {}", self.schema_url)),
+                    self.schema_span.offset(),
+                    self.schema_span.len(),
+                ),
+            ]
+            .into_iter(),
+        ))
+    }
+}
 
 /// A single diagnostic produced during validation, formatting, or parsing.
 #[derive(Debug, Error, Diagnostic)]
@@ -18,29 +80,9 @@ pub enum LintelDiagnostic {
         message: String,
     },
 
-    #[error("{message}")]
-    #[diagnostic(
-        code(lintel::validation),
-        url("{schema_url}"),
-        help("run `lintel explain --file {path}` to see the full schema definition")
-    )]
-    Validation {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("{label}")]
-        span: SourceSpan,
-        #[label("from {schema_url}")]
-        schema_span: SourceSpan,
-        path: String,
-        instance_path: String,
-        label: String,
-        message: String,
-        /// Schema URI this file was validated against (shown as a clickable link
-        /// in terminals for remote schemas).
-        schema_url: String,
-        /// JSON Schema path that triggered the error (e.g. `/properties/jobs/oneOf`).
-        schema_path: String,
-    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Validation(ValidationDiagnostic),
 
     #[error("{path}: mismatched $schema on line {line_number}: {message}")]
     #[diagnostic(code(lintel::jsonl::schema_mismatch))]
@@ -79,8 +121,8 @@ impl LintelDiagnostic {
     pub fn path(&self) -> &str {
         match self {
             LintelDiagnostic::Parse { src, .. } => src.name(),
-            LintelDiagnostic::Validation { path, .. }
-            | LintelDiagnostic::SchemaMismatch { path, .. }
+            LintelDiagnostic::Validation(v) => &v.path,
+            LintelDiagnostic::SchemaMismatch { path, .. }
             | LintelDiagnostic::Io { path, .. }
             | LintelDiagnostic::SchemaFetch { path, .. }
             | LintelDiagnostic::SchemaCompile { path, .. }
@@ -92,11 +134,11 @@ impl LintelDiagnostic {
     pub fn message(&self) -> &str {
         match self {
             LintelDiagnostic::Parse { message, .. }
-            | LintelDiagnostic::Validation { message, .. }
             | LintelDiagnostic::SchemaMismatch { message, .. }
             | LintelDiagnostic::Io { message, .. }
             | LintelDiagnostic::SchemaFetch { message, .. }
             | LintelDiagnostic::SchemaCompile { message, .. } => message,
+            LintelDiagnostic::Validation(v) => &v.message,
             LintelDiagnostic::Format { .. } => "file is not properly formatted",
         }
     }
@@ -104,9 +146,8 @@ impl LintelDiagnostic {
     /// Byte offset in the source file (for sorting).
     pub fn offset(&self) -> usize {
         match self {
-            LintelDiagnostic::Parse { span, .. } | LintelDiagnostic::Validation { span, .. } => {
-                span.offset()
-            }
+            LintelDiagnostic::Parse { span, .. } => span.offset(),
+            LintelDiagnostic::Validation(v) => v.span.offset(),
             LintelDiagnostic::SchemaMismatch { .. }
             | LintelDiagnostic::Io { .. }
             | LintelDiagnostic::SchemaFetch { .. }
@@ -327,7 +368,7 @@ mod tests {
                 "lintel::parse",
             ),
             (
-                LintelDiagnostic::Validation {
+                LintelDiagnostic::Validation(ValidationDiagnostic {
                     src: NamedSource::new("f", String::new()),
                     span: 0.into(),
                     schema_span: 0.into(),
@@ -337,8 +378,9 @@ mod tests {
                     message: String::new(),
                     schema_url: String::new(),
                     schema_path: String::new(),
-                },
-                "lintel::validation",
+                    validation_code: "lintel::validation::required".to_string(),
+                }),
+                "lintel::validation::required",
             ),
             (
                 LintelDiagnostic::SchemaMismatch {

--- a/crates/lintel-diagnostics/src/lib.rs
+++ b/crates/lintel-diagnostics/src/lib.rs
@@ -5,6 +5,7 @@ pub mod diagnostics;
 pub mod reporter;
 
 pub use diagnostics::{
-    DEFAULT_LABEL, LintelDiagnostic, find_instance_path_span, format_label, offset_to_line_col,
+    DEFAULT_LABEL, LintelDiagnostic, ValidationDiagnostic, find_instance_path_span, format_label,
+    offset_to_line_col,
 };
 pub use reporter::{CheckResult, CheckedFile, Reporter};

--- a/crates/lintel-explain/src/lib.rs
+++ b/crates/lintel-explain/src/lib.rs
@@ -468,21 +468,16 @@ async fn collect_validation_errors(
         .errors
         .into_iter()
         .filter_map(|err| {
-            if let lintel_diagnostics::LintelDiagnostic::Validation {
-                instance_path,
-                message,
-                ..
-            } = err
-            {
+            if let lintel_diagnostics::LintelDiagnostic::Validation(v) = err {
                 // When explaining the root, show all errors.
                 // Otherwise only show errors under the given property.
                 if instance_prefix.is_empty()
-                    || instance_path == instance_prefix
-                    || instance_path.starts_with(&format!("{instance_prefix}/"))
+                    || v.instance_path == instance_prefix
+                    || v.instance_path.starts_with(&format!("{instance_prefix}/"))
                 {
                     Some(jsonschema_explain::ExplainError {
-                        instance_path,
-                        message,
+                        instance_path: v.instance_path,
+                        message: v.message,
                     })
                 } else {
                     None

--- a/crates/lintel-github-action/src/lib.rs
+++ b/crates/lintel-github-action/src/lib.rs
@@ -69,10 +69,8 @@ struct Annotation {
 fn error_to_annotation(error: &LintelDiagnostic) -> Annotation {
     let path = error.path().replace('\\', "/");
     let (line, _col) = match error {
-        LintelDiagnostic::Parse { src, span, .. }
-        | LintelDiagnostic::Validation { src, span, .. } => {
-            offset_to_line_col(src.inner(), span.offset())
-        }
+        LintelDiagnostic::Parse { src, span, .. } => offset_to_line_col(src.inner(), span.offset()),
+        LintelDiagnostic::Validation(v) => offset_to_line_col(v.src.inner(), v.span.offset()),
         LintelDiagnostic::SchemaMismatch { line_number, .. } => (*line_number, 1),
         LintelDiagnostic::Io { .. }
         | LintelDiagnostic::SchemaFetch { .. }
@@ -82,10 +80,10 @@ fn error_to_annotation(error: &LintelDiagnostic) -> Annotation {
 
     let title = match error {
         LintelDiagnostic::Parse { .. } => Some("parse error".to_string()),
-        LintelDiagnostic::Validation { instance_path, .. } if instance_path != DEFAULT_LABEL => {
-            Some(instance_path.clone())
+        LintelDiagnostic::Validation(v) if v.instance_path != DEFAULT_LABEL => {
+            Some(v.instance_path.clone())
         }
-        LintelDiagnostic::Validation { .. } => Some("validation error".to_string()),
+        LintelDiagnostic::Validation(_) => Some("validation error".to_string()),
         LintelDiagnostic::SchemaMismatch { .. } => Some("schema mismatch".to_string()),
         LintelDiagnostic::Io { .. } => Some("io error".to_string()),
         LintelDiagnostic::SchemaFetch { .. } => Some("schema fetch error".to_string()),

--- a/crates/lintel-reporters/src/reporters/github.rs
+++ b/crates/lintel-reporters/src/reporters/github.rs
@@ -29,10 +29,8 @@ fn emit_lint_error(error: &LintelDiagnostic) {
     let message = escape_workflow(error.message());
 
     let (line, col) = match error {
-        LintelDiagnostic::Parse { src, span, .. }
-        | LintelDiagnostic::Validation { src, span, .. } => {
-            offset_to_line_col(src.inner(), span.offset())
-        }
+        LintelDiagnostic::Parse { src, span, .. } => offset_to_line_col(src.inner(), span.offset()),
+        LintelDiagnostic::Validation(v) => offset_to_line_col(v.src.inner(), v.span.offset()),
         LintelDiagnostic::SchemaMismatch { line_number, .. } => (*line_number, 1),
         LintelDiagnostic::Io { .. }
         | LintelDiagnostic::SchemaFetch { .. }
@@ -42,10 +40,8 @@ fn emit_lint_error(error: &LintelDiagnostic) {
 
     let title = match error {
         LintelDiagnostic::Parse { .. } => "parse error",
-        LintelDiagnostic::Validation { instance_path, .. } if instance_path != DEFAULT_LABEL => {
-            instance_path
-        }
-        LintelDiagnostic::Validation { .. } => "validation error",
+        LintelDiagnostic::Validation(v) if v.instance_path != DEFAULT_LABEL => &v.instance_path,
+        LintelDiagnostic::Validation(_) => "validation error",
         LintelDiagnostic::SchemaMismatch { .. } => "schema mismatch",
         LintelDiagnostic::Io { .. } => "io error",
         LintelDiagnostic::SchemaFetch { .. } => "schema fetch error",

--- a/crates/lintel-reporters/src/reporters/text.rs
+++ b/crates/lintel-reporters/src/reporters/text.rs
@@ -13,10 +13,12 @@ fn print_lint_errors(errors: &[LintelDiagnostic]) {
     for error in errors {
         let path = error.path();
         match error {
-            LintelDiagnostic::Validation { instance_path, .. }
-                if instance_path != DEFAULT_LABEL =>
-            {
-                eprintln!("error: {path}: {} (at {instance_path})", error.message(),);
+            LintelDiagnostic::Validation(v) if v.instance_path != DEFAULT_LABEL => {
+                eprintln!(
+                    "error: {path}: {} (at {})",
+                    error.message(),
+                    v.instance_path,
+                );
             }
             _ => {
                 eprintln!("error: {path}: {}", error.message());

--- a/crates/lintel-validate/src/validate.rs
+++ b/crates/lintel-validate/src/validate.rs
@@ -8,7 +8,9 @@ use glob::glob;
 use serde_json::Value;
 
 use lintel_diagnostics::reporter::{CheckResult, CheckedFile};
-use lintel_diagnostics::{DEFAULT_LABEL, LintelDiagnostic, find_instance_path_span, format_label};
+use lintel_diagnostics::{
+    DEFAULT_LABEL, LintelDiagnostic, ValidationDiagnostic, find_instance_path_span, format_label,
+};
 use lintel_schema_cache::{CacheStatus, SchemaCache};
 use lintel_validation_cache::{ValidationCacheStatus, ValidationError, ValidationErrorKind};
 use schema_catalog::{CompiledCatalog, FileFormat};
@@ -639,7 +641,7 @@ fn push_validation_errors(
         {
             message = format!("{message}; did you mean '{suggestion}'?");
         }
-        errors.push(LintelDiagnostic::Validation {
+        errors.push(LintelDiagnostic::Validation(ValidationDiagnostic {
             src: miette::NamedSource::new(&pf.path, pf.content.clone()),
             span: source_span,
             schema_span: source_span,
@@ -649,7 +651,8 @@ fn push_validation_errors(
             message,
             schema_url: schema_url.to_string(),
             schema_path: ve.schema_path.clone(),
-        });
+            validation_code: format!("lintel::validation::{}", ve.kind.as_ref()),
+        }));
     }
 }
 

--- a/crates/lintel-validation-cache/Cargo.toml
+++ b/crates/lintel-validation-cache/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 dirs = "6.0.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+strum.workspace = true
 sha2 = "0.10.9"
 tokio = { workspace = true, features = ["fs"] }
 

--- a/crates/lintel-validation-cache/src/validation_error.rs
+++ b/crates/lintel-validation-cache/src/validation_error.rs
@@ -20,8 +20,9 @@ pub struct ValidationError {
 ///
 /// Non-serializable nested errors (e.g. `AnyOf`, `OneOf*` context) drop their
 /// sub-error context. Non-serializable error types store a `message: String`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, strum::AsRefStr)]
 #[serde(tag = "type")]
+#[strum(serialize_all = "snake_case")]
 pub enum ValidationErrorKind {
     AdditionalItems {
         limit: usize,


### PR DESCRIPTION
## Summary
- Split the flat `lintel::validation` diagnostic code into per-kind codes (e.g. `lintel::validation::required`, `lintel::validation::additional_property`, `lintel::validation::type`)
- Use `strum::AsRefStr` with `serialize_all = "snake_case"` on `ValidationErrorKind` to derive code suffixes automatically from variant names
- Extract `ValidationDiagnostic` as a standalone struct with manual `Diagnostic` impl for dynamic codes, keeping `#[derive(Diagnostic)]` on the enum via `#[diagnostic(transparent)]`

## Test plan
- [x] All existing tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Error code test updated to verify granular codes