### PR TITLE
fix: diagnostic codes, property inference, and schema improvements

### DIFF
--- a/crates/lintel-diagnostics/src/diagnostics.rs
+++ b/crates/lintel-diagnostics/src/diagnostics.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 /// is available. Checked by reporters to decide whether to show the path suffix.
 pub const DEFAULT_LABEL: &str = "here";
 
-/// A validation diagnostic with a granular error code (e.g. `lintel::validation::required`).
+/// A validation diagnostic with a granular error code (e.g. `validation(required)`).
 ///
 /// Implements [`Diagnostic`] manually so the code can be computed at runtime
 /// from the [`ValidationErrorKind`](lintel_validation_cache::ValidationErrorKind).
@@ -24,7 +24,7 @@ pub struct ValidationDiagnostic {
     pub schema_url: String,
     /// JSON Schema path that triggered the error (e.g. `/properties/jobs/oneOf`).
     pub schema_path: String,
-    /// Granular diagnostic code (e.g. `lintel::validation::required`).
+    /// Granular diagnostic code (e.g. `validation(required)`).
     pub validation_code: String,
 }
 
@@ -71,7 +71,7 @@ impl Diagnostic for ValidationDiagnostic {
 #[derive(Debug, Error, Diagnostic)]
 pub enum LintelDiagnostic {
     #[error("{message}")]
-    #[diagnostic(code(lintel::parse))]
+    #[diagnostic(code(parse))]
     Parse {
         #[source_code]
         src: NamedSource<String>,
@@ -85,7 +85,7 @@ pub enum LintelDiagnostic {
     Validation(ValidationDiagnostic),
 
     #[error("{path}: mismatched $schema on line {line_number}: {message}")]
-    #[diagnostic(code(lintel::jsonl::schema_mismatch))]
+    #[diagnostic(code(jsonl::schema_mismatch))]
     SchemaMismatch {
         path: String,
         line_number: usize,
@@ -93,20 +93,20 @@ pub enum LintelDiagnostic {
     },
 
     #[error("{path}: {message}")]
-    #[diagnostic(code(lintel::io))]
+    #[diagnostic(code(io))]
     Io { path: String, message: String },
 
     #[error("{path}: {message}")]
-    #[diagnostic(code(lintel::schema::fetch))]
+    #[diagnostic(code(schema::fetch))]
     SchemaFetch { path: String, message: String },
 
     #[error("{path}: {message}")]
-    #[diagnostic(code(lintel::schema::compile))]
+    #[diagnostic(code(schema::compile))]
     SchemaCompile { path: String, message: String },
 
     #[error("Formatter would have printed the following content:\n\n{styled_path}\n\n{diff}")]
     #[diagnostic(
-        code(lintel::format),
+        code(format),
         help("run `lintel check --fix` or `lintel format` to fix formatting")
     )]
     Format {
@@ -365,7 +365,7 @@ mod tests {
                     span: 0.into(),
                     message: String::new(),
                 },
-                "lintel::parse",
+                "parse",
             ),
             (
                 LintelDiagnostic::Validation(ValidationDiagnostic {
@@ -378,9 +378,9 @@ mod tests {
                     message: String::new(),
                     schema_url: String::new(),
                     schema_path: String::new(),
-                    validation_code: "lintel::validation::required".to_string(),
+                    validation_code: "validation(required)".to_string(),
                 }),
-                "lintel::validation::required",
+                "validation(required)",
             ),
             (
                 LintelDiagnostic::SchemaMismatch {
@@ -388,28 +388,28 @@ mod tests {
                     line_number: 0,
                     message: String::new(),
                 },
-                "lintel::jsonl::schema_mismatch",
+                "jsonl::schema_mismatch",
             ),
             (
                 LintelDiagnostic::Io {
                     path: String::new(),
                     message: String::new(),
                 },
-                "lintel::io",
+                "io",
             ),
             (
                 LintelDiagnostic::SchemaFetch {
                     path: String::new(),
                     message: String::new(),
                 },
-                "lintel::schema::fetch",
+                "schema::fetch",
             ),
             (
                 LintelDiagnostic::SchemaCompile {
                     path: String::new(),
                     message: String::new(),
                 },
-                "lintel::schema::compile",
+                "schema::compile",
             ),
             (
                 LintelDiagnostic::Format {
@@ -417,7 +417,7 @@ mod tests {
                     styled_path: String::new(),
                     diff: String::new(),
                 },
-                "lintel::format",
+                "format",
             ),
         ];
 

--- a/crates/lintel-validate/src/validate.rs
+++ b/crates/lintel-validate/src/validate.rs
@@ -621,7 +621,7 @@ fn push_validation_errors(
             message,
             schema_url: schema_url.to_string(),
             schema_path: ve.schema_path.clone(),
-            validation_code: format!("lintel::validation::{}", ve.kind.as_ref()),
+            validation_code: format!("validation({})", ve.kind.as_ref()),
         }));
     }
 }

--- a/crates/lintel/src/main.rs
+++ b/crates/lintel/src/main.rs
@@ -221,7 +221,6 @@ fn setup_miette(global: &CLIGlobalOptions) {
         Box::new(
             miette::MietteHandlerOpts::new()
                 .terminal_links(true)
-                .context_lines(2)
                 .graphical_theme(color.clone())
                 .build(),
         )


### PR DESCRIPTION
## Summary
- Use shorter diagnostic codes and remove extra context lines
- Fix type inference corruption in properties maps with nested "properties" keys
- Migrate jsonschema-migrate to builder module with direct Schema construction
- Add Schema::absolute(), Schema::validate(), and allOf flattening
- Unify composition rendering and add schema fragment navigation
- Consolidate file discovery into lintel-config
- Add granular validation error codes (e.g. `lintel::validation::required`)
- Refactor extensions into modules, add IntelliJ extensions
- Render missing schema keywords in explain output
- Migrate musl builds from Nix to Cargo
- Dependency bumps: jsonschema 0.44.0, strum 0.28.0, actions/download-artifact 8

## Test plan
- [ ] Verify `cargo test --workspace` passes
- [ ] Test explain output renders correctly with `--extended` flag
- [ ] Validate granular error codes appear in lint output
- [ ] Confirm musl cross-compilation works in CI